### PR TITLE
Fix exponential backoff in fetchRawData

### DIFF
--- a/oralce/worker/client.go
+++ b/oralce/worker/client.go
@@ -48,7 +48,7 @@ func (hc *httpClient) fetchRawData(url string) ([]byte, error) {
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		if 0 < attempt {
 			retryDelay := time.Duration(1<<(attempt-1)) * time.Second
-			time.Sleep(max(retryDelay, config.RetryMaxDelaySec()))
+			time.Sleep(min(retryDelay, config.RetryMaxDelaySec()))
 		}
 
 		req, err := http.NewRequest(http.MethodGet, url, nil)


### PR DESCRIPTION
**Summary**
Fixes the incorrect use of max() in the retry backoff logic that was causing indefinite delays in oracle data fetching.

**Problem**
The fetchRawData function incorrectly used max() instead of min() for exponential backoff, resulting in:
1. Always sleeping for at least MaxDelaySec: Initial retries waited minimum 10 seconds instead of starting with shorter delays
2. Unbounded delay growth: With higher MaxAttempts, delay increases infinitely without a ceiling
3. Oracle data stalls: Prolonged waits during API flakiness caused missed price slots and SLA violations
4. Resource waste: Multiple workers stuck in unnecessarily long sleeps, delaying shutdown

**Changes**
```
// Before
time.Sleep(max(retryDelay, config.RetryMaxDelaySec()))

// After
time.Sleep(min(retryDelay, config.RetryMaxDelaySec()))
```