### PR TITLE
Fix time unit mismatch in Oracle job Period field

### DIFF
--- a/oralce/worker/pool.go
+++ b/oralce/worker/pool.go
@@ -78,7 +78,7 @@ func (wp *WorkerPool) ProcessRequestDoc(ctx context.Context, requestDoc oraclety
 		Path:   requestDoc.Endpoints[index].ParseRule,
 		Nonce:  max(currentNonce, requestDoc.Nonce),
 		Delay:  time.Duration(max(int64(0), dsec)) * time.Second,
-		Period: time.Duration(requestDoc.Period),
+		Period: time.Duration(requestDoc.Period) * time.Second,
 		Status: requestDoc.Status,
 	}
 
@@ -95,7 +95,7 @@ func (wp *WorkerPool) ProcessComplete(ctx context.Context, reqID string, nonce u
 	}
 
 	job.Nonce = max(job.Nonce, nonce)
-	periodSec := uint64(job.Period)
+	periodSec := uint64(job.Period / time.Second)
 	nowSec := uint64(time.Now().Unix())
 	tsSec := uint64(timestamp)
 	dsec := int64(tsSec+periodSec) - int64(nowSec)


### PR DESCRIPTION
**Summary**
Fixes a critical time unit mismatch where Oracle job periods were stored in nanoseconds instead of seconds, causing a 1 billion-fold discrepancy in job scheduling calculations.

**Problem**
The ProcessRequestDoc and ProcessComplete functions incorrectly handled the Period field unit conversion:
1. Storage Issue: requestDoc.Period (in seconds) was directly cast to time.Duration (nanoseconds) without multiplication
2. Retrieval Issue: job.Period (in nanoseconds) was cast to uint64 assuming it was in seconds
3. Result: Job periods were off by a factor of 1 billion (1,000,000,000)

**Changes**
1. Fixed Period storage
```
// Before
Period: time.Duration(requestDoc.Period),

// After
Period: time.Duration(requestDoc.Period) * time.Second,
```
2. Fixed Period retrieval
```
// Before
periodSec := uint64(job.Period)

// After
periodSec := uint64(job.Period / time.Second)
```