### PR TITLE
fix: check discount fro feeGranter

### DIFF
--- a/gurud/ante/cosmos_fees.go
+++ b/gurud/ante/cosmos_fees.go
@@ -71,8 +71,15 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	if err != nil {
 		return ctx, err
 	}
+	feeGranter := feePayer
+	if feeTx.FeeGranter() != nil {
+		feeGranter, err = addrCodec.BytesToString(feeTx.FeeGranter())
+		if err != nil {
+			return ctx, err
+		}
+	}
 
-	discount := dfd.feepolicyKeeper.GetDiscount(ctx, string(feePayer), tx.GetMsgs())
+	discount := dfd.feepolicyKeeper.GetDiscount(ctx, feeGranter, tx.GetMsgs())
 
 	// apply discounts
 	var deductedFee sdk.Coins


### PR DESCRIPTION
## Description
Fix for the [sherlock audit issue #146](https://github.com/sherlock-audit/2025-09-gurufin-chain/issues/146)

I have
- added a logic to check fee discount for feeGranter

Updated logic
- if feeGranter is not nil, check discount for feeGranter
- if feeGranter is nil, check discount for feePayer
- feeGranter cannot benefit from feePayer discounts