### PR TITLE
Fix shutdown logging

### DIFF
--- a/oralce/worker/pool.go
+++ b/oralce/worker/pool.go
@@ -34,8 +34,16 @@ func New(ctx context.Context, logger log.Logger) *WorkerPool {
 	wp.workerGroup, wp.workerFunc = taskgroup.New(nil).Limit(2 * runtime.NumCPU())
 	go func() {
 		<-ctx.Done()
-		wp.workerGroup.Wait()
+		wp.logger.Info("worker pool shutting down, waiting for active tasks to complete")
+
+		if err := wp.workerGroup.Wait(); err != nil {
+			wp.logger.Error("error during worker pool shutdown", "error", err)
+		} else {
+			wp.logger.Info("worker pool shutdown completed successfully")
+		}
+
 		close(wp.resultCh)
+		wp.logger.Debug("result channel closed")
 	}()
 
 	wp.client = newHTTPClient(wp.logger)
@@ -104,8 +112,8 @@ func (wp *WorkerPool) ProcessComplete(ctx context.Context, reqID string, nonce u
 	wp.executeJob(ctx, job)
 }
 
-// Results relturns a read-only channel of completed job results.
-// The channe is closed when the worker pool is shut down.
+// Results returns a read-only channel of completed job results.
+// The channel is closed when the worker pool is shut down.
 func (wp *WorkerPool) Results() <-chan *types.OracleJobResult {
 	return wp.resultCh
 }


### PR DESCRIPTION
### Summary
This PR addresses the missing error logging during worker pool shutdown, improving system observability as identified in the security audit Issue-164.

### Problem
The oracle worker pool's shutdown routine was silently discarding errors returned by `taskgroup.Wait()`. When HTTP fetches or other tasks failed during context cancellation, these diagnostic messages were lost, making it difficult for operators to identify issues during shutdown.

**Before:**
```go
go func() {
    <-ctx.Done()
    wp.workerGroup.Wait()  // Error ignored
    close(wp.resultCh)
}()
```

### Solution
Enhanced the shutdown logic with comprehensive logging to capture and report errors:
**After:**
```go
go func() {
    <-ctx.Done()
    wp.logger.Info("worker pool shutting down, waiting for active tasks to complete")

    if err := wp.workerGroup.Wait(); err != nil {
        wp.logger.Error("error during worker pool shutdown", "error", err)
    } else {
        wp.logger.Info("worker pool shutdown completed successfully")
    }

    close(wp.resultCh)
    wp.logger.Debug("result channel closed")
}()
```

### Changes
- File Modified: oralce/worker/pool.go
- Added: Error capture and logging for workerGroup.Wait()
- Added: Informational logs for shutdown start and completion
- Added: Debug log for result channel closure
- Fixed: Documentation typos ("relturns" → "returns", "channe" → "channel")