### PR TITLE
Audit/issue 170

### DIFF
--- a/ante/evm/fee_checker_test.go
+++ b/ante/evm/fee_checker_test.go
@@ -254,7 +254,7 @@ func TestSDKTxFeeChecker(t *testing.T) {
 			} else {
 				cfg.LondonBlock = big.NewInt(0)
 			}
-			fees, priority, err := evm.NewDynamicFeeChecker(tc.keeper)(tc.ctx, tc.buildTx())
+			fees, _, priority, err := evm.NewDynamicFeeChecker(tc.keeper)(tc.ctx, tc.buildTx())
 			if tc.expSuccess {
 				require.Equal(t, tc.expFees, fees.String())
 				require.Equal(t, tc.expPriority, priority)

--- a/gurud/ante/cosmos_fees.go
+++ b/gurud/ante/cosmos_fees.go
@@ -6,6 +6,7 @@ import (
 
 	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/math"
+	evmante "github.com/GPTx-global/guru-v2/v2/ante/evm"
 	feepolicytypes "github.com/GPTx-global/guru-v2/v2/x/feepolicy/types"
 	"github.com/cosmos/cosmos-sdk/codec/address"
 	authante "github.com/cosmos/cosmos-sdk/x/auth/ante"
@@ -23,11 +24,11 @@ type DeductFeeDecorator struct {
 	accountKeeper   authante.AccountKeeper
 	bankKeeper      types.BankKeeper
 	feegrantKeeper  authante.FeegrantKeeper
-	txFeeChecker    authante.TxFeeChecker
+	txFeeChecker    evmante.TxFeeChecker
 	feepolicyKeeper FeePolicyKeeper
 }
 
-func NewDeductFeeDecorator(ak authante.AccountKeeper, bk types.BankKeeper, fk authante.FeegrantKeeper, tfc authante.TxFeeChecker, fpk FeePolicyKeeper) DeductFeeDecorator {
+func NewDeductFeeDecorator(ak authante.AccountKeeper, bk types.BankKeeper, fk authante.FeegrantKeeper, tfc evmante.TxFeeChecker, fpk FeePolicyKeeper) DeductFeeDecorator {
 	if tfc == nil {
 		tfc = checkTxFeeWithValidatorMinGasPrices
 	}
@@ -57,8 +58,9 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	)
 
 	fee := feeTx.GetFee()
+	tips := sdk.Coins{}
 	if !simulate {
-		fee, priority, err = dfd.txFeeChecker(ctx, tx)
+		fee, tips, priority, err = dfd.txFeeChecker(ctx, tx)
 		if err != nil {
 			return ctx, err
 		}
@@ -83,23 +85,29 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 
 	// apply discounts
 	var deductedFee sdk.Coins
+	baseFee := fee.Sub(tips...)
 
 	if discount.DiscountType == feepolicytypes.FeeDiscountTypePercent {
-		for _, f := range fee {
-			// type: "percent"
-			// fee calculation: (100 - amount) % => if discount is 30%, then 70% of the fee is deducted
-			deductedFee = deductedFee.Add(sdk.NewCoin(f.Denom, f.Amount.MulRaw(math.LegacyNewDec(100).Sub(discount.Amount).TruncateInt64()).QuoRaw(100)))
+		for _, f := range baseFee {
+			// Calculate percentage multiplier as (100 - discountAmount) / 100
+			// Example: if discount = 25.5%, multiplier = 0.745
+			discountMultiplier := math.LegacyNewDec(100).Sub(discount.Amount).Quo(math.LegacyNewDec(100))
+
+			// Apply multiplier to base fee amount
+			finalAmt := math.LegacyNewDecFromInt(f.Amount).Mul(discountMultiplier).TruncateInt()
+
+			deductedFee = deductedFee.Add(sdk.NewCoin(f.Denom, finalAmt))
 		}
 	} else if discount.DiscountType == feepolicytypes.FeeDiscountTypeFixed {
-		for _, f := range fee {
+		for _, f := range baseFee {
 			// type: "fixed"
-			// fee calculation: fixed amount
 			deductedFee = deductedFee.Add(sdk.NewCoin(f.Denom, discount.Amount.TruncateInt()))
 		}
 	} else {
 		// if no discount, deduct full fee
-		deductedFee = fee
+		deductedFee = baseFee
 	}
+	deductedFee = deductedFee.Add(tips...)
 
 	if err = dfd.checkDeductFee(ctx, tx, deductedFee); err != nil {
 		return ctx, err

--- a/gurud/ante/handler_options.go
+++ b/gurud/ante/handler_options.go
@@ -1,6 +1,7 @@
 package ante
 
 import (
+	evmante "github.com/GPTx-global/guru-v2/v2/ante/evm"
 	anteinterfaces "github.com/GPTx-global/guru-v2/v2/ante/interfaces"
 	ibckeeper "github.com/cosmos/ibc-go/v10/modules/core/keeper"
 
@@ -30,7 +31,7 @@ type HandlerOptions struct {
 	SignModeHandler        *txsigning.HandlerMap
 	SigGasConsumer         func(meter storetypes.GasMeter, sig signing.SignatureV2, params authtypes.Params) error
 	MaxTxGasWanted         uint64
-	TxFeeChecker           ante.TxFeeChecker
+	TxFeeChecker           evmante.TxFeeChecker
 }
 
 // Validate checks if the keepers are defined

--- a/gurud/ante/validator_tx_fee.go
+++ b/gurud/ante/validator_tx_fee.go
@@ -12,10 +12,10 @@ import (
 
 // checkTxFeeWithValidatorMinGasPrices implements the default fee logic, where the minimum price per
 // unit of gas is fixed and set by each validator, can the tx priority is computed from the gas price.
-func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, int64, error) {
+func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins, sdk.Coins, int64, error) {
 	feeTx, ok := tx.(sdk.FeeTx)
 	if !ok {
-		return nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
+		return nil, nil, 0, errorsmod.Wrap(sdkerrors.ErrTxDecode, "Tx must be a FeeTx")
 	}
 
 	feeCoins := feeTx.GetFee()
@@ -38,13 +38,13 @@ func checkTxFeeWithValidatorMinGasPrices(ctx sdk.Context, tx sdk.Tx) (sdk.Coins,
 			}
 
 			if !feeCoins.IsAnyGTE(requiredFees) {
-				return nil, 0, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s required: %s", feeCoins, requiredFees)
+				return nil, nil, 0, errorsmod.Wrapf(sdkerrors.ErrInsufficientFee, "insufficient fees; got: %s required: %s", feeCoins, requiredFees)
 			}
 		}
 	}
 
 	priority := getTxPriority(feeCoins, int64(gas))
-	return feeCoins, priority, nil
+	return feeCoins, sdk.Coins{}, priority, nil
 }
 
 // getTxPriority returns a naive tx priority based on the amount of the smallest denomination of the gas price

--- a/server/swagger/embedded_protos_generated.go
+++ b/server/swagger/embedded_protos_generated.go
@@ -2,6 +2,160 @@
 
 package swagger
 
+// feepolicyQueryProto contains the content of ../../proto/guru/feepolicy/v1/query.proto
+const feepolicyQueryProto = `syntax = "proto3";
+
+package guru.feepolicy.v1;
+
+import "gogoproto/gogo.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "guru/feepolicy/v1/feepolicy.proto";
+import "google/api/annotations.proto";
+
+option go_package = "github.com/GPTx-global/guru-v2/v2/x/feepolicy/types";
+
+// Query provides defines the gRPC querier service.
+service Query {
+  // ModeratorAddress returns the current moderator address
+  rpc ModeratorAddress(QueryModeratorAddressRequest) 
+        returns (QueryModeratorAddressResponse) {
+    option (google.api.http).get = "/guru/feepolicy/v1/moderator_address";
+  }
+
+  // Discounts queries a denomination trace information.
+  rpc Discounts(QueryDiscountsRequest) returns (QueryDiscountsResponse) {
+    option (google.api.http).get = "/guru/feepolicy/v1/discounts";
+  }
+
+  // Discount queries a denomination trace information.
+  rpc Discount(QueryDiscountRequest) returns (QueryDiscountResponse) {
+    option (google.api.http).get = "/guru/feepolicy/v1/discounts/{address}";
+  }
+}
+
+// Request type for the Query/ModeratorAddress RPC method.
+message QueryModeratorAddressRequest {
+}
+
+// Response type for the Query/ModeratorAddress RPC method.
+message QueryModeratorAddressResponse {
+  string moderator_address = 1;
+}
+
+// QueryDiscountsRequest is the request type for the Query/Discounts RPC
+// method
+message QueryDiscountsRequest {
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+// QueryDiscountsResponse is the response type for the Query/Discounts RPC
+// method.
+message QueryDiscountsResponse {
+  repeated AccountDiscount discounts = 1 [(gogoproto.nullable) = false];
+  // pagination defines the pagination in the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryDiscountRequest is the request type for the Query/Discount RPC
+// method
+message QueryDiscountRequest {
+  string address = 1;
+}
+
+// QueryDiscountResponse is the response type for the Query/Discount RPC
+// method.
+message QueryDiscountResponse {
+  AccountDiscount discount = 1 [(gogoproto.nullable) = false];
+}
+`
+
+// feepolicyTxProto contains the content of ../../proto/guru/feepolicy/v1/tx.proto
+const feepolicyTxProto = `syntax = "proto3";
+
+package guru.feepolicy.v1;
+
+option go_package = "github.com/GPTx-global/guru-v2/v2/x/feepolicy/types";
+
+import "guru/feepolicy/v1/feepolicy.proto";
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+import "cosmos/base/v1beta1/coin.proto";
+import "cosmos/msg/v1/msg.proto";
+import "cosmos_proto/cosmos.proto";
+
+// Msg defines the feepolicy Msg service.
+service Msg {
+  option (cosmos.msg.v1.service) = true;
+  rpc RegisterDiscounts(MsgRegisterDiscounts) returns (MsgRegisterDiscountsResponse) {
+    option (google.api.http) = {
+      post: "/guru/feepolicy/v1/register_discounts"
+      body: "*"
+    };
+  }
+  rpc RemoveDiscounts(MsgRemoveDiscounts) returns (MsgRemoveDiscountsResponse) {
+    option (google.api.http) = {
+      post: "/guru/feepolicy/v1/remove_discounts"
+      body: "*"
+    };
+  }
+  rpc ChangeModerator(MsgChangeModerator) returns (MsgChangeModeratorResponse) {
+    option (google.api.http) = {
+      post: "/guru/feepolicy/v1/change_moderator"
+      body: "*"
+    };
+  }
+}
+
+message MsgRegisterDiscounts {
+  option (cosmos.msg.v1.signer) = "moderator_address";
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string   moderator_address                 = 1 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  repeated AccountDiscount discounts = 2 [
+    (gogoproto.nullable) = false
+  ];
+}
+
+message MsgRegisterDiscountsResponse{
+}
+
+message MsgRemoveDiscounts {
+  option (cosmos.msg.v1.signer) = "moderator_address";
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string   moderator_address                 = 1 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  
+  string address = 2;
+  string module = 3;
+  string msg_type = 4;
+}
+
+message MsgRemoveDiscountsResponse{
+}
+
+
+// msg declaration for changing the moderator.
+message MsgChangeModerator {
+  option (cosmos.msg.v1.signer) = "moderator_address";
+
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string   moderator_address                 = 1 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string   new_moderator_address     = 2 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+}
+
+// Response type for the Msg/ChangeModerator.
+message MsgChangeModeratorResponse {
+}`
+
 // oracleQueryProto contains the content of ../../proto/guru/oracle/v1/query.proto
 const oracleQueryProto = `syntax = "proto3";
 package guru.oracle.v1;
@@ -238,158 +392,4 @@ message MsgUpdateModeratorAddress {
 // MsgUpdateModeratorAddressResponse defines the Msg/UpdateModeratorAddress response type
 message MsgUpdateModeratorAddressResponse {} 
 `
-
-// feepolicyQueryProto contains the content of ../../proto/guru/feepolicy/v1/query.proto
-const feepolicyQueryProto = `syntax = "proto3";
-
-package guru.feepolicy.v1;
-
-import "gogoproto/gogo.proto";
-import "cosmos/base/query/v1beta1/pagination.proto";
-import "guru/feepolicy/v1/feepolicy.proto";
-import "google/api/annotations.proto";
-
-option go_package = "github.com/GPTx-global/guru-v2/v2/x/feepolicy/types";
-
-// Query provides defines the gRPC querier service.
-service Query {
-  // ModeratorAddress returns the current moderator address
-  rpc ModeratorAddress(QueryModeratorAddressRequest) 
-        returns (QueryModeratorAddressResponse) {
-    option (google.api.http).get = "/guru/feepolicy/v1/moderator_address";
-  }
-
-  // Discounts queries a denomination trace information.
-  rpc Discounts(QueryDiscountsRequest) returns (QueryDiscountsResponse) {
-    option (google.api.http).get = "/guru/feepolicy/v1/discounts";
-  }
-
-  // Discount queries a denomination trace information.
-  rpc Discount(QueryDiscountRequest) returns (QueryDiscountResponse) {
-    option (google.api.http).get = "/guru/feepolicy/v1/discounts/{address}";
-  }
-}
-
-// Request type for the Query/ModeratorAddress RPC method.
-message QueryModeratorAddressRequest {
-}
-
-// Response type for the Query/ModeratorAddress RPC method.
-message QueryModeratorAddressResponse {
-  string moderator_address = 1;
-}
-
-// QueryDiscountsRequest is the request type for the Query/Discounts RPC
-// method
-message QueryDiscountsRequest {
-  // pagination defines an optional pagination for the request.
-  cosmos.base.query.v1beta1.PageRequest pagination = 1;
-}
-
-// QueryDiscountsResponse is the response type for the Query/Discounts RPC
-// method.
-message QueryDiscountsResponse {
-  repeated AccountDiscount discounts = 1 [(gogoproto.nullable) = false];
-  // pagination defines the pagination in the response.
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
-}
-
-// QueryDiscountRequest is the request type for the Query/Discount RPC
-// method
-message QueryDiscountRequest {
-  string address = 1;
-}
-
-// QueryDiscountResponse is the response type for the Query/Discount RPC
-// method.
-message QueryDiscountResponse {
-  AccountDiscount discount = 1 [(gogoproto.nullable) = false];
-}
-`
-
-// feepolicyTxProto contains the content of ../../proto/guru/feepolicy/v1/tx.proto
-const feepolicyTxProto = `syntax = "proto3";
-
-package guru.feepolicy.v1;
-
-option go_package = "github.com/GPTx-global/guru-v2/v2/x/feepolicy/types";
-
-import "guru/feepolicy/v1/feepolicy.proto";
-import "gogoproto/gogo.proto";
-import "google/api/annotations.proto";
-import "cosmos/base/v1beta1/coin.proto";
-import "cosmos/msg/v1/msg.proto";
-import "cosmos_proto/cosmos.proto";
-
-// Msg defines the feepolicy Msg service.
-service Msg {
-  option (cosmos.msg.v1.service) = true;
-  rpc RegisterDiscounts(MsgRegisterDiscounts) returns (MsgRegisterDiscountsResponse) {
-    option (google.api.http) = {
-      post: "/guru/feepolicy/v1/register_discounts"
-      body: "*"
-    };
-  }
-  rpc RemoveDiscounts(MsgRemoveDiscounts) returns (MsgRemoveDiscountsResponse) {
-    option (google.api.http) = {
-      post: "/guru/feepolicy/v1/remove_discounts"
-      body: "*"
-    };
-  }
-  rpc ChangeModerator(MsgChangeModerator) returns (MsgChangeModeratorResponse) {
-    option (google.api.http) = {
-      post: "/guru/feepolicy/v1/change_moderator"
-      body: "*"
-    };
-  }
-}
-
-message MsgRegisterDiscounts {
-  option (cosmos.msg.v1.signer) = "moderator_address";
-  option (gogoproto.equal)           = false;
-  option (gogoproto.goproto_getters) = false;
-
-  string   moderator_address                 = 1 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  repeated AccountDiscount discounts = 2 [
-    (gogoproto.nullable) = false
-  ];
-}
-
-message MsgRegisterDiscountsResponse{
-}
-
-message MsgRemoveDiscounts {
-  option (cosmos.msg.v1.signer) = "moderator_address";
-  option (gogoproto.equal)           = false;
-  option (gogoproto.goproto_getters) = false;
-
-  string   moderator_address                 = 1 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  
-  string address = 2;
-  string module = 3;
-  string msg_type = 4;
-}
-
-message MsgRemoveDiscountsResponse{
-}
-
-
-// msg declaration for changing the moderator.
-message MsgChangeModerator {
-  option (cosmos.msg.v1.signer) = "moderator_address";
-
-  option (gogoproto.equal)           = false;
-  option (gogoproto.goproto_getters) = false;
-
-  string   moderator_address                 = 1 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string   new_moderator_address     = 2 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-}
-
-// Response type for the Msg/ChangeModerator.
-message MsgChangeModeratorResponse {
-}`
 


### PR DESCRIPTION
## Description
Fix for the [sherlock audit issue #170](https://github.com/sherlock-audit/2025-09-gurufin-chain/issues/170)

I have
- redefined the `TxFeeChecker` from `cosmos-sdk/x/auth/ante` into `guru-v2/ante/evm` with updated return objects
- `NewDynamicFeeChecker` now returns the new `TxFeeChecker` which also returns the `Tips` for the tx
- Updated the fee discount calculation in `AnteHandle` that allows the tips to be deducted as is without discounts

Updated logic
- Supports the tip calculation for both evm and cosmos type transactions 
- Supports both 0 and defined values for the `feemarket.BaseFee`