### PR TITLE
Prevent nonce desynchronization causing oracle feed halt

### DIFF
--- a/oralce/worker/pool.go
+++ b/oralce/worker/pool.go
@@ -112,6 +112,8 @@ func (wp *WorkerPool) Results() <-chan *types.OracleJobResult {
 
 // executeJob schedules a single job execution in a worker goroutine.
 // It honors ctx cancellation for delaying the first run.
+// The nonce is only incremented and persisted after all external operations succeed,
+// ensuring on-chain nonce consistency.
 func (wp *WorkerPool) executeJob(ctx context.Context, job *types.OracleJob) {
 	task := job
 
@@ -126,17 +128,21 @@ func (wp *WorkerPool) executeJob(ctx context.Context, job *types.OracleJob) {
 
 		reqID := strconv.FormatUint(task.ID, 10)
 
+		// Calculate next nonce but don't persist yet
+		var nextNonce uint64
 		if stored, ok := wp.jobStore.Get(reqID); ok {
-			task.Nonce = stored.Nonce + 1
+			nextNonce = stored.Nonce + 1
 		} else {
-			task.Nonce++
+			nextNonce = task.Nonce + 1
 		}
 
-		wp.jobStore.Set(reqID, task)
-
+		// Perform all external operations that may fail
 		rawData, err := wp.client.fetchRawData(task.URL)
 		if err != nil {
-			wp.logger.Error("failed to fetch raw data", "error", err)
+			wp.logger.Error("failed to fetch raw data",
+				"error", err,
+				"request_id", task.ID,
+				"nonce", nextNonce)
 			wp.resultCh <- nil
 			return err
 		}
@@ -144,22 +150,35 @@ func (wp *WorkerPool) executeJob(ctx context.Context, job *types.OracleJob) {
 
 		jsonData, err := wp.client.parseRawData(rawData)
 		if err != nil {
-			wp.logger.Error("failed to parse raw data", "error", err)
+			wp.logger.Error("failed to parse raw data",
+				"error", err,
+				"request_id", task.ID,
+				"nonce", nextNonce)
 			return err
 		}
 
 		result, err := wp.client.extractDataByPath(jsonData, task.Path)
 		if err != nil {
-			wp.logger.Error("failed to extract data by path", "error", err)
+			wp.logger.Error("failed to extract data by path",
+				"error", err,
+				"request_id", task.ID,
+				"nonce", nextNonce)
 			return err
 		}
+
+		// All operations succeeded - now persist the nonce increment
+		task.Nonce = nextNonce
+		wp.jobStore.Set(reqID, task)
 
 		wp.resultCh <- &types.OracleJobResult{
 			ID:    task.ID,
 			Data:  result,
 			Nonce: task.Nonce,
 		}
-		wp.logger.Debug("sent result to channel", "id", task.ID, "data", result)
+		wp.logger.Debug("sent result to channel",
+			"id", task.ID,
+			"data", result,
+			"nonce", task.Nonce)
 
 		return nil
 	})


### PR DESCRIPTION
### Summary
This PR fixes a critical bug in the oracle daemon's job execution that caused permanent oracle feed failures. The issue was that nonce increments were persisted before external operations completed, leading to on-chain nonce mismatches when operations failed.

### Vulnerability Details

**Critical Issue:**
The `executeJob` function in `oralce/worker/pool.go` was incrementing and persisting the nonce before performing external operations (fetch/parse/extract), which could fail:

**Before:**
```go
// Lines 129-135: Premature nonce increment and persistence
if stored, ok := wp.jobStore.Get(reqID); ok {
    task.Nonce = stored.Nonce + 1
} else {
    task.Nonce++
}
wp.jobStore.Set(reqID, task)  // Persisted before work is done

// Lines 137-155: External operations that may fail
rawData, err := wp.client.fetchRawData(task.URL)
if err != nil {
    return err  // Nonce incremented but data never submitted
}
```

### Solution
Implemented transactional nonce management using deferred persistence:

**After:**
```go
// Lines 131-137: Calculate next nonce but DON'T persist yet
var nextNonce uint64
if stored, ok := wp.jobStore.Get(reqID); ok {
    nextNonce = stored.Nonce + 1
} else {
    nextNonce = task.Nonce + 1
}

// Lines 139-167: Perform ALL external operations
rawData, err := wp.client.fetchRawData(task.URL)
if err != nil {
    wp.logger.Error("failed to fetch raw data",
        "error", err,
        "request_id", task.ID,
        "nonce", nextNonce)
    return err  // Nonce unchanged - can retry with same nonce
}

jsonData, err := wp.client.parseRawData(rawData)
if err != nil {
    wp.logger.Error("failed to parse raw data",
        "error", err,
        "request_id", task.ID,
        "nonce", nextNonce)
    return err  // Nonce unchanged
}

result, err := wp.client.extractDataByPath(jsonData, task.Path)
if err != nil {
    wp.logger.Error("failed to extract data by path",
        "error", err,
        "request_id", task.ID,
        "nonce", nextNonce)
    return err  // Nonce unchanged
}

// Lines 169-171: Only persist nonce after ALL operations succeed
task.Nonce = nextNonce
wp.jobStore.Set(reqID, task)  // Safe to persist now
```

### Changes
**File Modified:** oralce/worker/pool.go

Deferred Nonce Persistence (Lines 131-171):
- Compute nextNonce without persisting
- Execute all fallible external operations
- Only persist nonce if everything succeeds
- Ensures atomic state transition