### PR TITLE
test: add unit tests for feepolicy keeper and query functionalities

### DIFF
--- a/x/feepolicy/genesis_test.go
+++ b/x/feepolicy/genesis_test.go
@@ -1,0 +1,52 @@
+package feepolicy_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdkmath "cosmossdk.io/math"
+
+	"github.com/gurufinglobal/guru/v2/testutil/integration/os/network"
+	feepolicy "github.com/gurufinglobal/guru/v2/x/feepolicy"
+	"github.com/gurufinglobal/guru/v2/x/feepolicy/types"
+)
+
+func TestInitGenesisAndExportGenesis(t *testing.T) {
+	nw := network.NewUnitTestNetwork()
+	ctx := nw.GetContext()
+
+	authority := nw.App.FeePolicyKeeper.GetAuthority()
+
+	gs := types.GenesisState{
+		ModeratorAddress: "",
+		Discounts: []types.AccountDiscount{
+			{
+				Address: "guru1gzsvk8rruqn2sx64acfsskrwy8hvrmaf6dvhj3",
+				Modules: []types.ModuleDiscount{
+					{
+						Module: "bank",
+						Discounts: []types.Discount{
+							{
+								DiscountType: "percent",
+								MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+								Amount:       sdkmath.LegacyNewDec(100),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	feepolicy.InitGenesis(ctx, nw.App.FeePolicyKeeper, gs)
+
+	moderator, err := nw.App.FeePolicyKeeper.GetModeratorAddress(ctx)
+	require.NoError(t, err)
+	require.Equal(t, authority, moderator.Address)
+
+	exported := feepolicy.ExportGenesis(ctx, nw.App.FeePolicyKeeper)
+	require.Equal(t, authority, exported.ModeratorAddress)
+	require.Len(t, exported.Discounts, 1)
+	require.Equal(t, gs.Discounts[0], exported.Discounts[0])
+}

--- a/x/feepolicy/keeper/grpc_query_test.go
+++ b/x/feepolicy/keeper/grpc_query_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	sdkmath "cosmossdk.io/math"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/query"
 
@@ -93,6 +95,71 @@ func TestQueryDiscounts(t *testing.T) {
 			} else {
 				require.Error(t, err)
 			}
+		})
+	}
+}
+
+func TestQueryDiscount(t *testing.T) {
+	var (
+		nw  *network.UnitTestNetwork
+		ctx sdk.Context
+	)
+
+	testCases := []struct {
+		name    string
+		setup   func(ctx sdk.Context, nw *network.UnitTestNetwork) (string, *types.AccountDiscount)
+		expPass bool
+	}{
+		{
+			name: "pass - not found returns empty response",
+			setup: func(ctx sdk.Context, nw *network.UnitTestNetwork) (string, *types.AccountDiscount) {
+				return "guru1gzsvk8rruqn2sx64acfsskrwy8hvrmaf6dvhj3", nil
+			},
+			expPass: true,
+		},
+		{
+			name: "pass - found returns discount",
+			setup: func(ctx sdk.Context, nw *network.UnitTestNetwork) (string, *types.AccountDiscount) {
+				accDiscount := &types.AccountDiscount{
+					Address: "guru1gzsvk8rruqn2sx64acfsskrwy8hvrmaf6dvhj3",
+					Modules: []types.ModuleDiscount{
+						{
+							Module: "bank",
+							Discounts: []types.Discount{
+								{
+									DiscountType: "percent",
+									MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+									Amount:       sdkmath.LegacyNewDec(100),
+								},
+							},
+						},
+					},
+				}
+				nw.App.FeePolicyKeeper.SetAccountDiscounts(ctx, *accDiscount)
+				return accDiscount.Address, accDiscount
+			},
+			expPass: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// reset network and context
+			nw = network.NewUnitTestNetwork()
+			ctx = nw.GetContext()
+			qc := nw.GetFeePolicyClient()
+
+			addr, expDiscount := tc.setup(ctx, nw)
+
+			res, err := qc.Discount(ctx.Context(), &types.QueryDiscountRequest{Address: addr})
+			require.NoError(t, err)
+
+			if expDiscount == nil {
+				require.Equal(t, &types.QueryDiscountResponse{}, res)
+				return
+			}
+
+			require.Equal(t, &types.QueryDiscountResponse{Discount: *expDiscount}, res)
 		})
 	}
 }

--- a/x/feepolicy/keeper/keeper.go
+++ b/x/feepolicy/keeper/keeper.go
@@ -163,10 +163,10 @@ func (k Keeper) DeleteMsgTypeDiscounts(ctx sdk.Context, accStr, msgType string) 
 		return
 	}
 
-	for _, moduleDiscount := range discounts.Modules {
-		for j, discount := range moduleDiscount.Discounts {
+	for i := range discounts.Modules {
+		for j, discount := range discounts.Modules[i].Discounts {
 			if discount.MsgType == msgType {
-				moduleDiscount.Discounts = append(moduleDiscount.Discounts[:j], moduleDiscount.Discounts[j+1:]...)
+				discounts.Modules[i].Discounts = append(discounts.Modules[i].Discounts[:j], discounts.Modules[i].Discounts[j+1:]...)
 				break
 			}
 		}

--- a/x/feepolicy/keeper/keeper_test.go
+++ b/x/feepolicy/keeper/keeper_test.go
@@ -1,0 +1,132 @@
+package keeper_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	sdkmath "cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"github.com/gurufinglobal/guru/v2/testutil/integration/os/network"
+	"github.com/gurufinglobal/guru/v2/x/feepolicy/types"
+)
+
+func TestKeeperStoreOperations(t *testing.T) {
+	nw := network.NewUnitTestNetwork()
+	ctx := nw.GetContext()
+
+	const addr = "guru1gzsvk8rruqn2sx64acfsskrwy8hvrmaf6dvhj3"
+
+	accDiscount := types.AccountDiscount{
+		Address: addr,
+		Modules: []types.ModuleDiscount{
+			{
+				Module: "m1",
+				Discounts: []types.Discount{
+					{DiscountType: "percent", MsgType: "msg1", Amount: sdkmath.LegacyNewDec(100)},
+				},
+			},
+			{
+				Module: "m2",
+				Discounts: []types.Discount{
+					{DiscountType: "fixed", MsgType: "msg2", Amount: sdkmath.LegacyNewDec(1)},
+				},
+			},
+		},
+	}
+
+	nw.App.FeePolicyKeeper.SetAccountDiscounts(ctx, accDiscount)
+
+	got, ok := nw.App.FeePolicyKeeper.GetAccountDiscounts(ctx, addr)
+	require.True(t, ok)
+	require.Equal(t, accDiscount, got)
+
+	m1Discounts, ok := nw.App.FeePolicyKeeper.GetModuleDiscounts(ctx, addr, "m1")
+	require.True(t, ok)
+	require.Len(t, m1Discounts, 1)
+
+	nw.App.FeePolicyKeeper.DeleteModuleDiscounts(ctx, addr, "m1")
+
+	_, ok = nw.App.FeePolicyKeeper.GetModuleDiscounts(ctx, addr, "m1")
+	require.False(t, ok)
+
+	_, ok = nw.App.FeePolicyKeeper.GetModuleDiscounts(ctx, addr, "m2")
+	require.True(t, ok)
+
+	nw.App.FeePolicyKeeper.DeleteAccountDiscounts(ctx, addr)
+	_, ok = nw.App.FeePolicyKeeper.GetAccountDiscounts(ctx, addr)
+	require.False(t, ok)
+}
+
+func TestKeeperDeleteMsgTypeDiscounts(t *testing.T) {
+	nw := network.NewUnitTestNetwork()
+	ctx := nw.GetContext()
+
+	const addr = "guru1gzsvk8rruqn2sx64acfsskrwy8hvrmaf6dvhj3"
+
+	accDiscount := types.AccountDiscount{
+		Address: addr,
+		Modules: []types.ModuleDiscount{
+			{
+				Module: "bank",
+				Discounts: []types.Discount{
+					{DiscountType: "percent", MsgType: "/cosmos.bank.v1beta1.MsgSend", Amount: sdkmath.LegacyNewDec(100)},
+					{DiscountType: "fixed", MsgType: "/cosmos.bank.v1beta1.MsgMultiSend", Amount: sdkmath.LegacyNewDec(1)},
+				},
+			},
+		},
+	}
+	nw.App.FeePolicyKeeper.SetAccountDiscounts(ctx, accDiscount)
+
+	nw.App.FeePolicyKeeper.DeleteMsgTypeDiscounts(ctx, addr, "/cosmos.bank.v1beta1.MsgSend")
+
+	discounts, ok := nw.App.FeePolicyKeeper.GetModuleDiscounts(ctx, addr, "bank")
+	require.True(t, ok)
+	require.Len(t, discounts, 1)
+	require.Equal(t, "/cosmos.bank.v1beta1.MsgMultiSend", discounts[0].MsgType)
+}
+
+func TestKeeperGetDiscountAndLogger(t *testing.T) {
+	nw := network.NewUnitTestNetwork()
+	ctx := nw.GetContext()
+
+	const (
+		addr1 = "guru1gzsvk8rruqn2sx64acfsskrwy8hvrmaf6dvhj3"
+		addr2 = "guru1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg3d5d2"
+	)
+
+	// Ensure logger call is covered.
+	_ = nw.App.FeePolicyKeeper.Logger(ctx)
+
+	accDiscount := types.AccountDiscount{
+		Address: addr1,
+		Modules: []types.ModuleDiscount{
+			{
+				Module: "testmodule",
+				Discounts: []types.Discount{
+					{
+						DiscountType: "percent",
+						MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+						Amount:       sdkmath.LegacyNewDec(100),
+					},
+				},
+			},
+		},
+	}
+	nw.App.FeePolicyKeeper.SetAccountDiscounts(ctx, accDiscount)
+
+	msg := &banktypes.MsgSend{
+		FromAddress: addr1,
+		ToAddress:   addr2,
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin("agxn", 1)),
+	}
+
+	discount := nw.App.FeePolicyKeeper.GetDiscount(ctx, addr1, []sdk.Msg{msg})
+	require.Equal(t, accDiscount.Modules[0].Discounts[0], discount)
+
+	discount = nw.App.FeePolicyKeeper.GetDiscount(ctx, addr2, []sdk.Msg{msg})
+	require.Equal(t, types.Discount{}, discount)
+}


### PR DESCRIPTION
# Description

This PR adds unit test coverage for the `x/feepolicy` module, focusing on keeper/msg flows, gRPC queries, and genesis import/export behavior.

**Critical files to review**
- `x/feepolicy/keeper/msg_server_test.go`: msg server/keeper behavior (authority checks, register/remove discounts)
- `x/feepolicy/keeper/grpc_query_test.go`: gRPC query responses (moderator/discounts/discount)
- `x/feepolicy/keeper/keeper_test.go`: store operations + discount selection behavior
- `x/feepolicy/genesis_test.go`: `InitGenesis` / `ExportGenesis` expectations

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [ ] tackled an existing issue or discussed with a team member  
  - Note: N/A
- [x] left instructions on how to review the changes  
  - Review steps:
    - Run unit tests for `x/feepolicy` (or `make test-unit-cover`) and confirm the new test cases pass.
    - Review the not-found query contract: `QueryDiscount` returns an empty response when a discount is missing.
    - Validate `RemoveDiscounts` semantics match expectations (account-wide vs module vs msgType deletion).
- [ ] targeted the main branch (Note: this PR targets dev per release workflow)
  - Note: please retarget if needed (current branch: `feat/feepolicy-refactoring`)

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`  
  - Note: tests-only change; likely N/A unless project policy requires it
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed