### PR TITLE
fix(feepolicy): correctly delete msgType discounts in keeper store

### DIFF
--- a/x/feepolicy/keeper/keeper.go
+++ b/x/feepolicy/keeper/keeper.go
@@ -163,10 +163,10 @@ func (k Keeper) DeleteMsgTypeDiscounts(ctx sdk.Context, accStr, msgType string) 
 		return
 	}
 
-	for _, moduleDiscount := range discounts.Modules {
-		for j, discount := range moduleDiscount.Discounts {
+	for i := range discounts.Modules {
+		for j, discount := range discounts.Modules[i].Discounts {
 			if discount.MsgType == msgType {
-				moduleDiscount.Discounts = append(moduleDiscount.Discounts[:j], moduleDiscount.Discounts[j+1:]...)
+				discounts.Modules[i].Discounts = append(discounts.Modules[i].Discounts[:j], discounts.Modules[i].Discounts[j+1:]...)
 				break
 			}
 		}


### PR DESCRIPTION
# Description

This PR fixes a bug in `x/feepolicy` where deleting discounts by `msgType` was not actually persisted.

**Critical files to review**
- `x/feepolicy/keeper/keeper.go`: `DeleteMsgTypeDiscounts` fix (range-copy mutation → persisted update)

---

## Author Checklist

I have...

- [ ] tackled an existing issue or discussed with a team member  
  - Note: #XXXX
- [x] left instructions on how to review the changes  
  - Review steps:
    - Run unit tests covering `DeleteMsgTypeDiscounts` (e.g., `go test ./x/feepolicy/...` or `make test-unit-cover`).
    - Confirm that calling `DeleteMsgTypeDiscounts(ctx, addr, msgType)` removes the target discount and the updated discounts are persisted in the store.
- [ ] targeted the `main` branch  
  - Note: retarget if required by workflow.

## Reviewers Checklist

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`  
  - Note: N/A if changelog is not required for internal bugfixes (per project policy)
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed