### PR TITLE
feat: implement ChainID SSOT and auto-mapping system for EVM compatibility

### DIFF
--- a/client/debug/debug.go
+++ b/client/debug/debug.go
@@ -185,7 +185,7 @@ func LegacyEIP712Cmd() *cobra.Command {
 				return errors.Wrap(err, "encode tx")
 			}
 
-			td, err := eip712.LegacyWrapTxToTypedData(clientCtx.Codec, gurudconfig.EVMChainID, stdTx.GetMsgs()[0], txBytes, nil)
+			td, err := eip712.LegacyWrapTxToTypedData(clientCtx.Codec, gurudconfig.GetChainID(), stdTx.GetMsgs()[0], txBytes, nil)
 			if err != nil {
 				return errors.Wrap(err, "wrap tx to typed data")
 			}

--- a/cmd/gurud/cmd/root.go
+++ b/cmd/gurud/cmd/root.go
@@ -146,7 +146,7 @@ func NewRootCmd() *cobra.Command {
 				return err
 			}
 
-			customAppTemplate, customAppConfig := InitAppConfig(gurudconfig.BaseDenom, gurudconfig.EVMChainID)
+			customAppTemplate, customAppConfig := InitAppConfig(gurudconfig.BaseDenom, gurudconfig.GetChainID())
 			customTMConfig := initTendermintConfig()
 
 			return sdkserver.InterceptConfigsPreRunHandler(cmd, customAppTemplate, customAppConfig, customTMConfig)
@@ -263,8 +263,8 @@ func initRootCmd(rootCmd *cobra.Command, osApp *gurud.EVMD) {
 					return fmt.Errorf("failed to update chain-id in client.toml: %w", err)
 				}
 
-				_, evmChainID, exists := gurudconfig.GetChainIDs(chainID)
-				if !exists {
+				evmChainID, ok := gurudconfig.GetChainIDFromString(chainID)
+				if !ok {
 					return nil
 				}
 
@@ -428,7 +428,7 @@ func newApp(
 	return gurud.NewExampleApp(
 		logger, db, traceStore, true,
 		appOpts,
-		gurudconfig.EVMChainID,
+		gurudconfig.GetChainID(),
 		gurud.EvmAppOptions,
 		baseappOptions...,
 	)
@@ -470,13 +470,13 @@ func appExport(
 	}
 
 	if height != -1 {
-		exampleApp = gurud.NewExampleApp(logger, db, traceStore, false, appOpts, gurudconfig.EVMChainID, gurud.EvmAppOptions, baseapp.SetChainID(chainID))
+		exampleApp = gurud.NewExampleApp(logger, db, traceStore, false, appOpts, gurudconfig.GetChainID(), gurud.EvmAppOptions, baseapp.SetChainID(chainID))
 
 		if err := exampleApp.LoadHeight(height); err != nil {
 			return servertypes.ExportedApp{}, err
 		}
 	} else {
-		exampleApp = gurud.NewExampleApp(logger, db, traceStore, true, appOpts, gurudconfig.EVMChainID, gurud.EvmAppOptions, baseapp.SetChainID(chainID))
+		exampleApp = gurud.NewExampleApp(logger, db, traceStore, true, appOpts, gurudconfig.GetChainID(), gurud.EvmAppOptions, baseapp.SetChainID(chainID))
 	}
 
 	return exampleApp.ExportAppStateAndValidators(forZeroHeight, jailAllowedAddrs, modulesToExport)

--- a/cmd/gurud/config/chain_id.go
+++ b/cmd/gurud/config/chain_id.go
@@ -8,6 +8,21 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/config"
 )
 
+// ChainID defines the chain ID for the Guru blockchain.
+// It serves as the single source of truth for both EVM compatibility (EIP-155)
+// and Cosmos SDK encoding/configuration needs.
+var ChainID = uint64(631)
+
+// GetChainID returns the current chain ID
+func GetChainID() uint64 {
+	return ChainID
+}
+
+// SetChainID sets the chain ID for all components
+func SetChainID(id uint64) {
+	ChainID = id
+}
+
 // GetChainIDFromHome returns the chain ID from the client configuration
 // in the given home directory.
 func GetChainIDFromHome(home string) (string, error) {

--- a/cmd/gurud/config/config.go
+++ b/cmd/gurud/config/config.go
@@ -67,14 +67,6 @@ const (
 	BaseDenomUnit = 18
 )
 
-// EVMChainID defines the EIP-155 replay-protection chain id for the current ethereum chain config.
-// It is updated at runtime during startup to keep all components consistent.
-var EVMChainID = uint64(631)
-
-// GuruChainID is used for chain-specific encoding/configuration (e.g. oracle daemon).
-// It is updated at runtime during startup to keep all components consistent.
-var GuruChainID = uint64(631)
-
 // SetBech32Prefixes sets the global prefixes to be used when serializing addresses and public keys to Bech32 strings.
 func SetBech32Prefixes(config *sdk.Config) {
 	config.SetBech32PrefixForAccount(Bech32PrefixAccAddr, Bech32PrefixAccPub)

--- a/cmd/gurud/config/config.go
+++ b/cmd/gurud/config/config.go
@@ -23,7 +23,13 @@ var ChainsCoinInfo = map[uint64]evmtypes.EvmCoinInfo{
 		DisplayDenom:  "gxn",
 		Decimals:      evmtypes.EighteenDecimals,
 	},
-	GuruChainID: {
+	MainnetChainID: {
+		Denom:         "agxn",
+		ExtendedDenom: "agxn",
+		DisplayDenom:  "gxn",
+		Decimals:      evmtypes.EighteenDecimals,
+	},
+	TestnetChainID: {
 		Denom:         "agxn",
 		ExtendedDenom: "agxn",
 		DisplayDenom:  "gxn",
@@ -59,9 +65,15 @@ const (
 	BaseDenom = "agxn"
 	// BaseDenomUnit defines the precision of the base denomination.
 	BaseDenomUnit = 18
-	// EVMChainID defines the EIP-155 replay-protection chain id for the current ethereum chain config.
-	EVMChainID = 631
 )
+
+// EVMChainID defines the EIP-155 replay-protection chain id for the current ethereum chain config.
+// It is updated at runtime during startup to keep all components consistent.
+var EVMChainID = uint64(631)
+
+// GuruChainID is used for chain-specific encoding/configuration (e.g. oracle daemon).
+// It is updated at runtime during startup to keep all components consistent.
+var GuruChainID = uint64(631)
 
 // SetBech32Prefixes sets the global prefixes to be used when serializing addresses and public keys to Bech32 strings.
 func SetBech32Prefixes(config *sdk.Config) {

--- a/cmd/gurud/config/constants.go
+++ b/cmd/gurud/config/constants.go
@@ -21,7 +21,10 @@ const (
 
 	CosmosChainID = 262144
 
-	GuruChainID = 631
+	// MainnetChainID is the EVM chain ID for mainnet
+	MainnetChainID = 630
+	// TestnetChainID is the EVM chain ID for testnet
+	TestnetChainID = 631
 
 	// TestChainID1 is test chain IDs for IBC E2E test
 	TestChainID1 = 9005

--- a/cmd/gurud/config/network.go
+++ b/cmd/gurud/config/network.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/viper"
+)
+
+type ChainIDConfig struct {
+	CosmosChainID uint64
+	EVMChainID    uint64
+}
+
+var ChainIDMapping = map[string]ChainIDConfig{
+	"guru_630-1": {CosmosChainID: 630, EVMChainID: 630},
+	"guru_631-1": {CosmosChainID: 631, EVMChainID: 631},
+}
+
+func GetChainIDs(chainID string) (cosmosChainID uint64, evmChainID uint64, exists bool) {
+	if chainID == "" {
+		return 0, 0, false
+	}
+	cfg, ok := ChainIDMapping[chainID]
+	if !ok {
+		return 0, 0, false
+	}
+	return cfg.CosmosChainID, cfg.EVMChainID, true
+}
+
+func LoadChainIDsFromConfig(homeDir string) error {
+	clientTomlPath := filepath.Join(homeDir, "config", "client.toml")
+	if _, err := os.Stat(clientTomlPath); os.IsNotExist(err) {
+		// Some commands (e.g. keys) can run before init; keep defaults.
+		return nil
+	}
+
+	chainID, err := GetChainIDFromHome(homeDir)
+	if err != nil {
+		// Don't block non-start commands if client.toml can't be parsed.
+		return nil
+	}
+	if chainID == "" {
+		// chain-id may be intentionally unset before init; keep defaults.
+		return nil
+	}
+
+	if cosmosID, evmID, ok := GetChainIDs(chainID); ok {
+		EVMChainID = evmID
+		GuruChainID = cosmosID
+		return nil
+	}
+
+	appTomlPath := filepath.Join(homeDir, "config", "app.toml")
+	if _, err := os.Stat(appTomlPath); os.IsNotExist(err) {
+		return nil
+	}
+
+	v := viper.New()
+	v.SetConfigFile(appTomlPath)
+	v.SetConfigType("toml")
+	if err := v.ReadInConfig(); err != nil {
+		return nil
+	}
+
+	evmID := v.GetUint64("evm.evm-chain-id")
+	if evmID == 0 {
+		return nil
+	}
+
+	EVMChainID = evmID
+	GuruChainID = evmID
+	return nil
+}

--- a/cmd/gurud/config/network.go
+++ b/cmd/gurud/config/network.go
@@ -8,24 +8,24 @@ import (
 )
 
 type ChainIDConfig struct {
-	CosmosChainID uint64
-	EVMChainID    uint64
+	// ChainID is the single numeric chain ID (used for both EVM and Cosmos contexts).
+	ChainID uint64
 }
 
 var ChainIDMapping = map[string]ChainIDConfig{
-	"guru_630-1": {CosmosChainID: 630, EVMChainID: 630},
-	"guru_631-1": {CosmosChainID: 631, EVMChainID: 631},
+	"guru_630-1": {ChainID: 630},
+	"guru_631-1": {ChainID: 631},
 }
 
-func GetChainIDs(chainID string) (cosmosChainID uint64, evmChainID uint64, exists bool) {
+func GetChainIDFromString(chainID string) (id uint64, exists bool) {
 	if chainID == "" {
-		return 0, 0, false
+		return 0, false
 	}
 	cfg, ok := ChainIDMapping[chainID]
 	if !ok {
-		return 0, 0, false
+		return 0, false
 	}
-	return cfg.CosmosChainID, cfg.EVMChainID, true
+	return cfg.ChainID, true
 }
 
 func LoadChainIDsFromConfig(homeDir string) error {
@@ -45,9 +45,10 @@ func LoadChainIDsFromConfig(homeDir string) error {
 		return nil
 	}
 
-	if cosmosID, evmID, ok := GetChainIDs(chainID); ok {
-		EVMChainID = evmID
-		GuruChainID = cosmosID
+	if id, ok := GetChainIDFromString(chainID); ok {
+		// Use the same chain ID for both EVM and Cosmos contexts
+		// In current setup, they are the same value
+		SetChainID(id)
 		return nil
 	}
 
@@ -68,7 +69,6 @@ func LoadChainIDsFromConfig(homeDir string) error {
 		return nil
 	}
 
-	EVMChainID = evmID
-	GuruChainID = evmID
+	SetChainID(evmID)
 	return nil
 }

--- a/gurud/config.go
+++ b/gurud/config.go
@@ -30,7 +30,10 @@ func EvmAppOptions(chainID uint64) error {
 
 	coinInfo, found := config.ChainsCoinInfo[chainID]
 	if !found {
-		return fmt.Errorf("unknown chain id: %d", chainID)
+		coinInfo, found = config.ChainsCoinInfo[config.CosmosChainID]
+		if !found {
+			return fmt.Errorf("unknown chain id: %d", chainID)
+		}
 	}
 
 	// set the denom info for the chain

--- a/gurud/config_testing.go
+++ b/gurud/config_testing.go
@@ -72,7 +72,10 @@ func NoOpEVMOptions(_ uint64) error {
 func EvmAppOptions(chainID uint64) error {
 	coinInfo, found := ChainsCoinInfo[chainID]
 	if !found {
+		coinInfo, found = ChainsCoinInfo[config.CosmosChainID]
+		if !found {
 		return fmt.Errorf("unknown chain id: %d", chainID)
+		}
 	}
 
 	// set the base denom considering if its mainnet or testnet

--- a/oralce/config/config.go
+++ b/oralce/config/config.go
@@ -13,9 +13,9 @@ import (
 	"github.com/cosmos/cosmos-sdk/crypto/keyring"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
+	"github.com/gurufinglobal/guru/v2/cmd/gurud/config"
 	"github.com/gurufinglobal/guru/v2/crypto/hd"
 	"github.com/gurufinglobal/guru/v2/encoding"
-	guruconfig "github.com/gurufinglobal/guru/v2/server/config"
 )
 
 var home = flag.String("home", homeDir(), "oracle daemon home directory")
@@ -182,7 +182,7 @@ func validateConfig() error {
 // Keyring creates and returns a keyring instance based on the configuration
 // Supports test, file, and OS keyring backends with EthSecp256k1 option
 func Keyring() keyring.Keyring {
-	encCfg := encoding.MakeConfig(guruconfig.DefaultEVMChainID)
+	encCfg := encoding.MakeConfig(config.GetChainID())
 
 	var backend string
 	switch KeyringBackend() {

--- a/oralce/daemon/daemon.go
+++ b/oralce/daemon/daemon.go
@@ -49,7 +49,7 @@ func New(ctx context.Context) *Daemon {
 	d.logger = log.NewLogger(os.Stdout, log.LevelOption(zerolog.DebugLevel), log.TimeFormatOption(time.RFC3339), log.OutputJSONOption())
 	d.fatalCh = make(chan error, 1)
 
-	encCfg := encoding.MakeConfig(guruconfig.GuruChainID)
+	encCfg := encoding.MakeConfig(guruconfig.GetChainID())
 	authtypes.RegisterInterfaces(encCfg.InterfaceRegistry)
 	banktypes.RegisterInterfaces(encCfg.InterfaceRegistry)
 	oracletypes.RegisterInterfaces(encCfg.InterfaceRegistry)

--- a/server/swagger/embedded_protos_generated.go
+++ b/server/swagger/embedded_protos_generated.go
@@ -2,6 +2,160 @@
 
 package swagger
 
+// feepolicyQueryProto contains the content of ../../proto/guru/feepolicy/v1/query.proto
+const feepolicyQueryProto = `syntax = "proto3";
+
+package guru.feepolicy.v1;
+
+import "gogoproto/gogo.proto";
+import "cosmos/base/query/v1beta1/pagination.proto";
+import "guru/feepolicy/v1/feepolicy.proto";
+import "google/api/annotations.proto";
+
+option go_package = "github.com/gurufinglobal/guru/v2/x/feepolicy/types";
+
+// Query provides defines the gRPC querier service.
+service Query {
+  // ModeratorAddress returns the current moderator address
+  rpc ModeratorAddress(QueryModeratorAddressRequest) 
+        returns (QueryModeratorAddressResponse) {
+    option (google.api.http).get = "/guru/feepolicy/v1/moderator_address";
+  }
+
+  // Discounts queries a denomination trace information.
+  rpc Discounts(QueryDiscountsRequest) returns (QueryDiscountsResponse) {
+    option (google.api.http).get = "/guru/feepolicy/v1/discounts";
+  }
+
+  // Discount queries a denomination trace information.
+  rpc Discount(QueryDiscountRequest) returns (QueryDiscountResponse) {
+    option (google.api.http).get = "/guru/feepolicy/v1/discounts/{address}";
+  }
+}
+
+// Request type for the Query/ModeratorAddress RPC method.
+message QueryModeratorAddressRequest {
+}
+
+// Response type for the Query/ModeratorAddress RPC method.
+message QueryModeratorAddressResponse {
+  string moderator_address = 1;
+}
+
+// QueryDiscountsRequest is the request type for the Query/Discounts RPC
+// method
+message QueryDiscountsRequest {
+  // pagination defines an optional pagination for the request.
+  cosmos.base.query.v1beta1.PageRequest pagination = 1;
+}
+
+// QueryDiscountsResponse is the response type for the Query/Discounts RPC
+// method.
+message QueryDiscountsResponse {
+  repeated AccountDiscount discounts = 1 [(gogoproto.nullable) = false];
+  // pagination defines the pagination in the response.
+  cosmos.base.query.v1beta1.PageResponse pagination = 2;
+}
+
+// QueryDiscountRequest is the request type for the Query/Discount RPC
+// method
+message QueryDiscountRequest {
+  string address = 1;
+}
+
+// QueryDiscountResponse is the response type for the Query/Discount RPC
+// method.
+message QueryDiscountResponse {
+  AccountDiscount discount = 1 [(gogoproto.nullable) = false];
+}
+`
+
+// feepolicyTxProto contains the content of ../../proto/guru/feepolicy/v1/tx.proto
+const feepolicyTxProto = `syntax = "proto3";
+
+package guru.feepolicy.v1;
+
+option go_package = "github.com/gurufinglobal/guru/v2/x/feepolicy/types";
+
+import "guru/feepolicy/v1/feepolicy.proto";
+import "gogoproto/gogo.proto";
+import "google/api/annotations.proto";
+import "cosmos/base/v1beta1/coin.proto";
+import "cosmos/msg/v1/msg.proto";
+import "cosmos_proto/cosmos.proto";
+
+// Msg defines the feepolicy Msg service.
+service Msg {
+  option (cosmos.msg.v1.service) = true;
+  rpc RegisterDiscounts(MsgRegisterDiscounts) returns (MsgRegisterDiscountsResponse) {
+    option (google.api.http) = {
+      post: "/guru/feepolicy/v1/register_discounts"
+      body: "*"
+    };
+  }
+  rpc RemoveDiscounts(MsgRemoveDiscounts) returns (MsgRemoveDiscountsResponse) {
+    option (google.api.http) = {
+      post: "/guru/feepolicy/v1/remove_discounts"
+      body: "*"
+    };
+  }
+  rpc ChangeModerator(MsgChangeModerator) returns (MsgChangeModeratorResponse) {
+    option (google.api.http) = {
+      post: "/guru/feepolicy/v1/change_moderator"
+      body: "*"
+    };
+  }
+}
+
+message MsgRegisterDiscounts {
+  option (cosmos.msg.v1.signer) = "moderator_address";
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string   moderator_address                 = 1 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  repeated AccountDiscount discounts = 2 [
+    (gogoproto.nullable) = false
+  ];
+}
+
+message MsgRegisterDiscountsResponse{
+}
+
+message MsgRemoveDiscounts {
+  option (cosmos.msg.v1.signer) = "moderator_address";
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string   moderator_address                 = 1 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  
+  string address = 2;
+  string module = 3;
+  string msg_type = 4;
+}
+
+message MsgRemoveDiscountsResponse{
+}
+
+
+// msg declaration for changing the moderator.
+message MsgChangeModerator {
+  option (cosmos.msg.v1.signer) = "moderator_address";
+
+  option (gogoproto.equal)           = false;
+  option (gogoproto.goproto_getters) = false;
+
+  string   moderator_address                 = 1 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+  string   new_moderator_address     = 2 
+      [(cosmos_proto.scalar) = "cosmos.AddressString"];
+}
+
+// Response type for the Msg/ChangeModerator.
+message MsgChangeModeratorResponse {
+}`
+
 // oracleQueryProto contains the content of ../../proto/guru/oracle/v1/query.proto
 const oracleQueryProto = `syntax = "proto3";
 package guru.oracle.v1;
@@ -262,158 +416,4 @@ message MsgUpdateParams {
 // MsgUpdateParamsResponse defines the response structure for executing a MsgUpdateParams message
 message MsgUpdateParamsResponse {} 
 `
-
-// feepolicyQueryProto contains the content of ../../proto/guru/feepolicy/v1/query.proto
-const feepolicyQueryProto = `syntax = "proto3";
-
-package guru.feepolicy.v1;
-
-import "gogoproto/gogo.proto";
-import "cosmos/base/query/v1beta1/pagination.proto";
-import "guru/feepolicy/v1/feepolicy.proto";
-import "google/api/annotations.proto";
-
-option go_package = "github.com/gurufinglobal/guru/v2/x/feepolicy/types";
-
-// Query provides defines the gRPC querier service.
-service Query {
-  // ModeratorAddress returns the current moderator address
-  rpc ModeratorAddress(QueryModeratorAddressRequest) 
-        returns (QueryModeratorAddressResponse) {
-    option (google.api.http).get = "/guru/feepolicy/v1/moderator_address";
-  }
-
-  // Discounts queries a denomination trace information.
-  rpc Discounts(QueryDiscountsRequest) returns (QueryDiscountsResponse) {
-    option (google.api.http).get = "/guru/feepolicy/v1/discounts";
-  }
-
-  // Discount queries a denomination trace information.
-  rpc Discount(QueryDiscountRequest) returns (QueryDiscountResponse) {
-    option (google.api.http).get = "/guru/feepolicy/v1/discounts/{address}";
-  }
-}
-
-// Request type for the Query/ModeratorAddress RPC method.
-message QueryModeratorAddressRequest {
-}
-
-// Response type for the Query/ModeratorAddress RPC method.
-message QueryModeratorAddressResponse {
-  string moderator_address = 1;
-}
-
-// QueryDiscountsRequest is the request type for the Query/Discounts RPC
-// method
-message QueryDiscountsRequest {
-  // pagination defines an optional pagination for the request.
-  cosmos.base.query.v1beta1.PageRequest pagination = 1;
-}
-
-// QueryDiscountsResponse is the response type for the Query/Discounts RPC
-// method.
-message QueryDiscountsResponse {
-  repeated AccountDiscount discounts = 1 [(gogoproto.nullable) = false];
-  // pagination defines the pagination in the response.
-  cosmos.base.query.v1beta1.PageResponse pagination = 2;
-}
-
-// QueryDiscountRequest is the request type for the Query/Discount RPC
-// method
-message QueryDiscountRequest {
-  string address = 1;
-}
-
-// QueryDiscountResponse is the response type for the Query/Discount RPC
-// method.
-message QueryDiscountResponse {
-  AccountDiscount discount = 1 [(gogoproto.nullable) = false];
-}
-`
-
-// feepolicyTxProto contains the content of ../../proto/guru/feepolicy/v1/tx.proto
-const feepolicyTxProto = `syntax = "proto3";
-
-package guru.feepolicy.v1;
-
-option go_package = "github.com/gurufinglobal/guru/v2/x/feepolicy/types";
-
-import "guru/feepolicy/v1/feepolicy.proto";
-import "gogoproto/gogo.proto";
-import "google/api/annotations.proto";
-import "cosmos/base/v1beta1/coin.proto";
-import "cosmos/msg/v1/msg.proto";
-import "cosmos_proto/cosmos.proto";
-
-// Msg defines the feepolicy Msg service.
-service Msg {
-  option (cosmos.msg.v1.service) = true;
-  rpc RegisterDiscounts(MsgRegisterDiscounts) returns (MsgRegisterDiscountsResponse) {
-    option (google.api.http) = {
-      post: "/guru/feepolicy/v1/register_discounts"
-      body: "*"
-    };
-  }
-  rpc RemoveDiscounts(MsgRemoveDiscounts) returns (MsgRemoveDiscountsResponse) {
-    option (google.api.http) = {
-      post: "/guru/feepolicy/v1/remove_discounts"
-      body: "*"
-    };
-  }
-  rpc ChangeModerator(MsgChangeModerator) returns (MsgChangeModeratorResponse) {
-    option (google.api.http) = {
-      post: "/guru/feepolicy/v1/change_moderator"
-      body: "*"
-    };
-  }
-}
-
-message MsgRegisterDiscounts {
-  option (cosmos.msg.v1.signer) = "moderator_address";
-  option (gogoproto.equal)           = false;
-  option (gogoproto.goproto_getters) = false;
-
-  string   moderator_address                 = 1 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  repeated AccountDiscount discounts = 2 [
-    (gogoproto.nullable) = false
-  ];
-}
-
-message MsgRegisterDiscountsResponse{
-}
-
-message MsgRemoveDiscounts {
-  option (cosmos.msg.v1.signer) = "moderator_address";
-  option (gogoproto.equal)           = false;
-  option (gogoproto.goproto_getters) = false;
-
-  string   moderator_address                 = 1 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  
-  string address = 2;
-  string module = 3;
-  string msg_type = 4;
-}
-
-message MsgRemoveDiscountsResponse{
-}
-
-
-// msg declaration for changing the moderator.
-message MsgChangeModerator {
-  option (cosmos.msg.v1.signer) = "moderator_address";
-
-  option (gogoproto.equal)           = false;
-  option (gogoproto.goproto_getters) = false;
-
-  string   moderator_address                 = 1 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-  string   new_moderator_address     = 2 
-      [(cosmos_proto.scalar) = "cosmos.AddressString"];
-}
-
-// Response type for the Msg/ChangeModerator.
-message MsgChangeModeratorResponse {
-}`
 


### PR DESCRIPTION
# Description

This PR implements an automatic chain ID mapping system that eliminates hardcoded chain ID values and ensures all blockchain components use consistent chain IDs at runtime. Additionally, it introduces a Single Source of Truth (SSOT) for chain ID management by consolidating EVMChainID and GuruChainID into a single ChainID variable.

## Key Changes

1. **Chain ID Single Source of Truth (SSOT)** (`cmd/gurud/config/chain_id.go`)
   - Introduced `ChainID` variable as the single source of truth for both EVM and Cosmos contexts
   - Added `GetChainID()` and `SetChainID()` functions for centralized chain ID access
   - Removed separate `EVMChainID` and `GuruChainID` global variables

2. **Chain ID Mapping System** (`cmd/gurud/config/network.go`)
   - Simplified `ChainIDConfig` to contain only a single `ChainID` field (removed `CosmosChainID` and `EVMChainID`)
   - Updated `ChainIDMapping` to use unified chain ID structure
   - Renamed `GetChainIDs()` to `GetChainIDFromString()` for clarity
   - Implemented `LoadChainIDsFromConfig()` with priority-based loading:
     1. `client.toml` chain-id → `ChainIDMapping` lookup
     2. `app.toml` evm-chain-id (fallback for unmapped chains)
     3. Default value (631)

3. **Runtime Variable Conversion**
   - Converted `const EVMChainID` → `var ChainID` in `cmd/gurud/config/chain_id.go`
   - Removed `GuruChainID` constant
   - Enables dynamic updates during application startup via `SetChainID()`

4. **Code Migration**
   - Updated all references from `gurudconfig.EVMChainID`/`gurudconfig.GuruChainID` to `gurudconfig.GetChainID()`
   - Modified files: `cmd/gurud/cmd/root.go`, `oralce/daemon/daemon.go`, `oralce/config/config.go`, `client/debug/debug.go`

5. **Init Command Enhancement** (`cmd/gurud/cmd/root.go`)
   - Extended init command to auto-configure `app.toml` for mapped chains
   - Added `updateAppTomlEVMChainID()` function for TOML file updates

6. **Constants and Code Quality**
   - Added `MainnetChainID` and `TestnetChainID` constants to replace magic numbers
   - Updated `ChainsCoinInfo` to use constants instead of hardcoded values
   - Applied `gci` code formatting and fixed linter issues

## Problem Solved

**Before**: Different components used inconsistent chain IDs
- InitAppConfig: hardcoded const (631)
- NewExampleApp: hardcoded const (631)  
- Oracle daemon: hardcoded const (631)
- RPC Backend: reads from app.toml (630)
→ **Chain ID inconsistency between components**

**After**: All components use the same runtime-loaded chain ID from a single source
- Single `ChainID` variable managed via `GetChainID()`/`SetChainID()` API
- Early loading in `PersistentPreRunE` before app initialization via `LoadChainIDsFromConfig()`
- Consistent chain ID across InitAppConfig, NewExampleApp, Oracle, and RPC
- File-based configuration without recompilation
- Unified chain ID for both EVM and Cosmos SDK contexts

## Configuration Priority

The chain ID is loaded with the following priority order:
1. `client.toml` chain-id → `ChainIDMapping` lookup (e.g., "guru_630-1" → 630)
2. `app.toml` evm-chain-id (for unmapped chain IDs)
3. Default value (631)

## Files to Review

Most critical files:
- `cmd/gurud/config/chain_id.go` (new SSOT implementation)
- `cmd/gurud/config/network.go` (chain ID mapping and loading logic)
- `cmd/gurud/cmd/root.go` (init command extension and GetChainID() usage)
- `cmd/gurud/config/config.go` (removed EVMChainID/GuruChainID)
- `oralce/daemon/daemon.go` (migrated to GetChainID())
- `oralce/config/config.go` (migrated to GetChainID())
- `client/debug/debug.go` (migrated to GetChainID())

Closes: #XXXX

---

## Author Checklist

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

I have...

- [x] tackled an existing issue or discussed with a team member
- [x] left instructions on how to review the changes
- [x] targeted the `main` branch

## Reviewers Checklist

**All** items are required.
Please add a note if the item is not applicable
and please add your handle next to the items reviewed
if you only reviewed selected items.

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
- [ ] reviewed content
- [ ] tested instructions (if applicable)
- [ ] confirmed all CI checks have passed