### PR TITLE
docs: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ This is forked from cosmos/evm [v0.3.1](https://github.com/cosmos/evm/tree/v0.3.
 
 # Guru Chain
 
-[![version](https://img.shields.io/github/v/tag/gurufinglobal/guru.svg)](https://github.com/gurufinglobal/guru/v2/releases/latest)
+[![version](https://img.shields.io/github/v/tag/gurufinglobal/guru.svg)](https://github.com/gurufinglobal/guru/releases/latest)
 [![Go version](https://img.shields.io/badge/go-1.24.6+-green.svg)](https://github.com/moovweb/gvm)
 <!-- admin widget setting: https://shields.io/badges/discord
 
@@ -11,23 +11,26 @@ This is forked from cosmos/evm [v0.3.1](https://github.com/cosmos/evm/tree/v0.3.
 -->
 
 
-[Guru Chain](https://github.com/gurufinglobal/guru/v2/PAPER.md) is forked from Cosmos EVM [v0.3.1](https://github.com/cosmos/evm/releases/tag/v0.3.1) on 2025-08.
+Guru Chain is forked from Cosmos EVM [v0.3.1](https://github.com/cosmos/evm/releases/tag/v0.3.1) on 2025-08.
+
+Audited by Sherlock (October 2025).
+A link to the final audit report can be found [here](https://github.com/gurufinglobal/guru/blob/d03f48445d6ee3810f5becde9a334f2ae61cb059/docs/audits/Gurufin_Sherlock_Audit_final_Report_2025_10_31.pdf).
 
 ## Releases
 
-Please do not depend on `main` as your production branch. Use [releases](https://github.com/gurufinglobal/guru/v2/releases) instead.
+Please do not depend on `main` as your production branch. Use [releases](https://github.com/gurufinglobal/guru/releases) instead.
 
 ## Minimum requirements
 
 | Requirement | Notes              |
 | ----------- |--------------------|
-| Go version  | Go1.24.6 or higher |
+| Go version  | Go1.24.11 or higher |
 
 
 # Quick Start
 ## git clone
 ```
-git clone https://github.com/gurufinglobal/guru/v2.git
+git clone https://github.com/gurufinglobal/guru.git
 ```
 
 ## Test & Cover
@@ -68,4 +71,4 @@ For more detailed information, please refer to the [Guru documentation](https://
 ## Research
 
 - [The latest gossip on BFT consensus](https://arxiv.org/abs/1807.04938)
-- Original Guru Whitepaper
+- [Original Gurufin Whitepaper](https://img.gurufin.app/gurufin/white_paper.pdf)


### PR DESCRIPTION
## Summary
- Fix GitHub links in README (releases and clone URL).
- Update minimum Go version requirement to Go1.24.11.
- Add audit report reference and update whitepaper link.

## Test plan
- N/A (documentation-only change)