### PR TITLE
fix(transwap): prevent refund packet data overwrite in IBC callbacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	cosmossdk.io/x/upgrade v0.2.0
 	github.com/btcsuite/btcd v0.24.2
 	github.com/btcsuite/btcd/btcutil v1.1.6
-	github.com/cometbft/cometbft v0.38.19
+	github.com/cometbft/cometbft v0.38.21
 	github.com/cosmos/cosmos-db v1.1.1
 	github.com/cosmos/cosmos-proto v1.0.0-beta.5
 	github.com/cosmos/cosmos-sdk v0.53.4
@@ -278,7 +278,7 @@ replace (
 	github.com/cockroachdb/pebble => github.com/cockroachdb/pebble v0.0.0-20230928194634-aa077af62593
 	// Fix GO-2025-4025: CometBFT's invalid BitArray handling can lead to network halt
 	// Note: GO-2025-3442 requires v1.0.1 (major upgrade), consider upgrading separately
-	github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.38.19
+	github.com/cometbft/cometbft => github.com/cometbft/cometbft v0.38.21
 	// Fix GO-2025-4087: Unchecked memory allocation during vector deserialization
 	github.com/consensys/gnark-crypto => github.com/consensys/gnark-crypto v0.18.1
 	// use guru fork of cosmos-sdk

--- a/go.sum
+++ b/go.sum
@@ -831,8 +831,8 @@ github.com/cockroachdb/redact v1.1.6/go.mod h1:BVNblN9mBWFyMyqK1k3AAiSxhvhfK2oOZ
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06 h1:zuQyyAKVxetITBuuhv3BI9cMrmStnpT18zmgmTxunpo=
 github.com/cockroachdb/tokenbucket v0.0.0-20230807174530-cc333fc44b06/go.mod h1:7nc4anLGjupUW/PeY5qiNYsdNXj7zopG+eqsS7To5IQ=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
-github.com/cometbft/cometbft v0.38.19 h1:vNdtCkvhuwUlrcLPAyigV7lQpmmo+tAq8CsB8gZjEYw=
-github.com/cometbft/cometbft v0.38.19/go.mod h1:UCu8dlHqvkAsmAFmWDRWNZJPlu6ya2fTWZlDrWsivwo=
+github.com/cometbft/cometbft v0.38.21 h1:qcIJSH9LiwU5s6ZgKR5eRbsLNucbubfraDs5bzgjtOI=
+github.com/cometbft/cometbft v0.38.21/go.mod h1:UCu8dlHqvkAsmAFmWDRWNZJPlu6ya2fTWZlDrWsivwo=
 github.com/cometbft/cometbft-db v0.14.1 h1:SxoamPghqICBAIcGpleHbmoPqy+crij/++eZz3DlerQ=
 github.com/cometbft/cometbft-db v0.14.1/go.mod h1:KHP1YghilyGV/xjD5DP3+2hyigWx0WTp9X+0Gnx0RxQ=
 github.com/consensys/gnark-crypto v0.18.1 h1:RyLV6UhPRoYYzaFnPQA4qK3DyuDgkTgskDdoGqFt3fI=

--- a/precompiles/p256/integration_test.go
+++ b/precompiles/p256/integration_test.go
@@ -103,10 +103,10 @@ var _ = Describe("Calling p256 precompile directly", Label("P256 Precompile"), O
 
 					input = make([]byte, p256.VerifyInputLength)
 					copy(input[0:32], hash)
-					copy(input[32:64], rInt.Bytes())
-					copy(input[64:96], sInt.Bytes())
-					copy(input[96:128], privB.X.Bytes())
-					copy(input[128:160], privB.Y.Bytes())
+					rInt.FillBytes(input[32:64])
+					sInt.FillBytes(input[64:96])
+					privB.X.FillBytes(input[96:128])
+					privB.Y.FillBytes(input[128:160])
 					return input, nil, ""
 				},
 			),
@@ -161,10 +161,10 @@ var _ = Describe("Calling p256 precompile directly", Label("P256 Precompile"), O
 
 					input = make([]byte, p256.VerifyInputLength)
 					copy(input[0:32], hash)
-					copy(input[32:64], rInt.Bytes())
-					copy(input[64:96], sInt.Bytes())
-					copy(input[96:128], privB.X.Bytes())
-					copy(input[128:160], privB.Y.Bytes())
+					rInt.FillBytes(input[32:64])
+					sInt.FillBytes(input[64:96])
+					privB.X.FillBytes(input[96:128])
+					privB.Y.FillBytes(input[128:160])
 					return input
 				},
 			),

--- a/precompiles/p256/p256_test.go
+++ b/precompiles/p256/p256_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -64,8 +65,8 @@ func (s *PrecompileTestSuite) TestRun() {
 
 				input := make([]byte, p256.VerifyInputLength)
 				copy(input[0:32], hash)
-				copy(input[32:64], rBz)
-				copy(input[64:96], sBz)
+				new(big.Int).SetBytes(rBz).FillBytes(input[32:64])
+				new(big.Int).SetBytes(sBz).FillBytes(input[64:96])
 				s.p256Priv.X.FillBytes(input[96:128])
 				s.p256Priv.Y.FillBytes(input[128:160])
 

--- a/precompiles/p256/setup_test.go
+++ b/precompiles/p256/setup_test.go
@@ -53,10 +53,10 @@ func signMsg(msg []byte, priv *ecdsa.PrivateKey) []byte {
 
 	input := make([]byte, p256.VerifyInputLength)
 	copy(input[0:32], hash)
-	copy(input[32:64], rInt.Bytes())
-	copy(input[64:96], sInt.Bytes())
-	copy(input[96:128], priv.X.Bytes())
-	copy(input[128:160], priv.Y.Bytes())
+	rInt.FillBytes(input[32:64])
+	sInt.FillBytes(input[64:96])
+	priv.X.FillBytes(input[96:128])
+	priv.Y.FillBytes(input[128:160])
 
 	return input
 }

--- a/x/ibc/transwap/ibc_module.go
+++ b/x/ibc/transwap/ibc_module.go
@@ -251,7 +251,7 @@ func (im IBCModule) OnAcknowledgementPacket(
 
 	// acknowledgement
 	if data.IsTransferPacket() {
-		err = im.keeper.OnAcknowledgementTransferPacket(ctx, packet.SourcePort, packet.SourceChannel, data, ack)
+		err = im.keeper.OnAcknowledgementTransferPacket(ctx, packet.SourcePort, packet.SourceChannel, packet.Sequence, data, ack)
 	} else {
 		err = im.keeper.OnAcknowledgementExchangePacket(ctx, packet.SourcePort, packet.SourceChannel, data, ack)
 	}
@@ -278,7 +278,7 @@ func (im IBCModule) OnTimeoutPacket(
 
 	// refund tokens
 	if data.IsTransferPacket() {
-		err = im.keeper.OnTimeoutTransferPacket(ctx, packet.SourcePort, packet.SourceChannel, data)
+		err = im.keeper.OnTimeoutTransferPacket(ctx, packet.SourcePort, packet.SourceChannel, packet.Sequence, data)
 	} else {
 		err = im.keeper.OnTimeoutExchangePacket(ctx, packet.SourcePort, packet.SourceChannel, data)
 	}

--- a/x/ibc/transwap/keeper/keeper.go
+++ b/x/ibc/transwap/keeper/keeper.go
@@ -290,8 +290,8 @@ func (k Keeper) IsBlockedAddr(addr sdk.AccAddress) bool {
 	return k.BankKeeper.BlockedAddr(addr)
 }
 
-// RefundPacketDataKey builds a deterministic key for refund packet data.
-func RefundPacketDataKey(sourcePort, sourceChannel string, sequence uint64) string {
+// GetRefundPacketDataKey builds a deterministic key for refund packet data.
+func GetRefundPacketDataKey(sourcePort, sourceChannel string, sequence uint64) string {
 	return fmt.Sprintf("refund/%s/%s/%d", sourcePort, sourceChannel, sequence)
 }
 

--- a/x/ibc/transwap/keeper/keeper.go
+++ b/x/ibc/transwap/keeper/keeper.go
@@ -290,6 +290,11 @@ func (k Keeper) IsBlockedAddr(addr sdk.AccAddress) bool {
 	return k.BankKeeper.BlockedAddr(addr)
 }
 
+// RefundPacketDataKey builds a deterministic key for refund packet data.
+func RefundPacketDataKey(sourcePort, sourceChannel string, sequence uint64) string {
+	return fmt.Sprintf("refund/%s/%s/%d", sourcePort, sourceChannel, sequence)
+}
+
 func (k Keeper) SetRefundPacketData(ctx sdk.Context, key string, packet *types.TransferPacketData) error {
 	if packet == nil {
 		return fmt.Errorf("packet cannot be nil")

--- a/x/ibc/transwap/keeper/msg_server.go
+++ b/x/ibc/transwap/keeper/msg_server.go
@@ -14,7 +14,7 @@ import (
 	"github.com/gurufinglobal/guru/v2/x/ibc/transwap/types"
 )
 
-func (k Keeper) transferV1Packet(ctx sdk.Context, sourceChannel string, token types.Token, timeoutTimestamp uint64, packetData types.FungibleTokenPacketData) (uint64, error) { //nolint:unparam
+func (k Keeper) transferV1Packet(ctx sdk.Context, sourceChannel string, token types.Token, timeoutTimestamp uint64, packetData types.FungibleTokenPacketData) (uint64, error) {
 	if err := k.SendTransfer(ctx, types.PortID, sourceChannel, token, sdk.MustAccAddressFromBech32(packetData.Sender)); err != nil {
 		return 0, err
 	}
@@ -31,7 +31,7 @@ func (k Keeper) transferV1Packet(ctx sdk.Context, sourceChannel string, token ty
 	return sequence, nil
 }
 
-func (k Keeper) transferV2Packet(ctx sdk.Context, encoding, sourceChannel string, timeoutTimestamp uint64, packetData types.FungibleTokenPacketData) (uint64, error) { //nolint:unparam
+func (k Keeper) transferV2Packet(ctx sdk.Context, encoding, sourceChannel string, timeoutTimestamp uint64, packetData types.FungibleTokenPacketData) (uint64, error) {
 	if encoding == "" {
 		encoding = types.EncodingJSON
 	}

--- a/x/ibc/transwap/keeper/refund_packet_data_test.go
+++ b/x/ibc/transwap/keeper/refund_packet_data_test.go
@@ -72,7 +72,7 @@ func setupRefundKeeper(t *testing.T) (Keeper, sdk.Context) {
 }
 
 func TestRefundPacketDataKey(t *testing.T) {
-	key := RefundPacketDataKey(transtypes.PortID, "channel-7", 42)
+	key := GetRefundPacketDataKey(transtypes.PortID, "channel-7", 42)
 	require.Equal(t, "refund/transwap/channel-7/42", key)
 }
 
@@ -105,8 +105,8 @@ func TestRefundPacketData_IsolatedBySequenceForSameReceiver(t *testing.T) {
 		"2",
 	)
 
-	key1 := RefundPacketDataKey(transtypes.PortID, "channel-0", 1)
-	key2 := RefundPacketDataKey(transtypes.PortID, "channel-0", 2)
+	key1 := GetRefundPacketDataKey(transtypes.PortID, "channel-0", 1)
+	key2 := GetRefundPacketDataKey(transtypes.PortID, "channel-0", 2)
 
 	require.NoError(t, k.SetRefundPacketData(ctx, key1, &packet1))
 	require.NoError(t, k.SetRefundPacketData(ctx, key2, &packet2))

--- a/x/ibc/transwap/keeper/refund_packet_data_test.go
+++ b/x/ibc/transwap/keeper/refund_packet_data_test.go
@@ -1,0 +1,137 @@
+package keeper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+
+	tmdb "github.com/cosmos/cosmos-db"
+
+	"cosmossdk.io/log"
+	"cosmossdk.io/math"
+	"cosmossdk.io/store"
+	"cosmossdk.io/store/metrics"
+	storetypes "cosmossdk.io/store/types"
+
+	"github.com/cosmos/cosmos-sdk/codec"
+	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	bextypes "github.com/gurufinglobal/guru/v2/x/bex/types"
+	transtypes "github.com/gurufinglobal/guru/v2/x/ibc/transwap/types"
+)
+
+type refundBexKeeperMock struct{}
+
+func (refundBexKeeperMock) GetExchange(ctx sdk.Context, exchangeID math.Int) (*bextypes.Exchange, error) {
+	return nil, nil
+}
+
+func (refundBexKeeperMock) AddCollectedFees(ctx sdk.Context, exchangeID string, fees sdk.Coins) error {
+	return nil
+}
+
+func (refundBexKeeperMock) DeductCollectedFees(ctx sdk.Context, exchangeID string, fees sdk.Coins) error {
+	return nil
+}
+
+func (refundBexKeeperMock) LockExchangeFees(ctx sdk.Context, exchangeID string, fees sdk.Coins) error {
+	return nil
+}
+
+func (refundBexKeeperMock) ReleaseExchangeFees(ctx sdk.Context, exchangeID string, fees sdk.Coins) error {
+	return nil
+}
+
+func setupRefundKeeper(t *testing.T) (Keeper, sdk.Context) {
+	t.Helper()
+
+	storeKey := storetypes.NewKVStoreKey(transtypes.StoreKey)
+
+	db := tmdb.NewMemDB()
+	stateStore := store.NewCommitMultiStore(db, log.NewNopLogger(), metrics.NewNoOpMetrics())
+	stateStore.MountStoreWithDB(storeKey, storetypes.StoreTypeDB, db)
+	require.NoError(t, stateStore.LoadLatestVersion())
+
+	registry := codectypes.NewInterfaceRegistry()
+	cdc := codec.NewProtoCodec(registry)
+
+	ctx := sdk.NewContext(stateStore, tmproto.Header{ChainID: "test-chain"}, false, log.NewNopLogger()).
+		WithGasMeter(storetypes.NewInfiniteGasMeter())
+
+	k := Keeper{
+		storeService: runtime.NewKVStoreService(storeKey),
+		cdc:          cdc,
+		BexKeeper:    refundBexKeeperMock{},
+	}
+
+	return k, ctx
+}
+
+func TestRefundPacketDataKey(t *testing.T) {
+	key := RefundPacketDataKey(transtypes.PortID, "channel-7", 42)
+	require.Equal(t, "refund/transwap/channel-7/42", key)
+}
+
+func TestRefundPacketData_IsolatedBySequenceForSameReceiver(t *testing.T) {
+	k, ctx := setupRefundKeeper(t)
+
+	receiver := "same-receiver"
+	token := transtypes.Token{Denom: transtypes.NewDenom("uatom"), Amount: "100"}
+
+	packet1 := transtypes.NewTransferPacketData(
+		transtypes.PortID,
+		"channel-0",
+		token,
+		"reserve-address-1",
+		receiver,
+		"memo-1",
+		1,
+		sdk.NewInt64Coin("uatom", 1),
+		"1",
+	)
+	packet2 := transtypes.NewTransferPacketData(
+		transtypes.PortID,
+		"channel-0",
+		token,
+		"reserve-address-2",
+		receiver,
+		"memo-2",
+		2,
+		sdk.NewInt64Coin("uatom", 2),
+		"2",
+	)
+
+	key1 := RefundPacketDataKey(transtypes.PortID, "channel-0", 1)
+	key2 := RefundPacketDataKey(transtypes.PortID, "channel-0", 2)
+
+	require.NoError(t, k.SetRefundPacketData(ctx, key1, &packet1))
+	require.NoError(t, k.SetRefundPacketData(ctx, key2, &packet2))
+
+	got1, err := k.GetRefundPacketData(ctx, key1)
+	require.NoError(t, err)
+	require.Equal(t, packet1.ExchangeId, got1.ExchangeId)
+	require.Equal(t, packet1.Sender, got1.Sender)
+	require.Equal(t, packet1.Receiver, got1.Receiver)
+	require.Equal(t, packet1.Fee, got1.Fee)
+
+	got2, err := k.GetRefundPacketData(ctx, key2)
+	require.NoError(t, err)
+	require.Equal(t, packet2.ExchangeId, got2.ExchangeId)
+	require.Equal(t, packet2.Sender, got2.Sender)
+	require.Equal(t, packet2.Receiver, got2.Receiver)
+	require.Equal(t, packet2.Fee, got2.Fee)
+
+	// deleting one sequence entry must not affect the other sequence entry
+	k.DeleteRefundPacketData(ctx, key1)
+
+	_, err = k.GetRefundPacketData(ctx, key1)
+	require.Error(t, err)
+
+	stillPresent, err := k.GetRefundPacketData(ctx, key2)
+	require.NoError(t, err)
+	require.Equal(t, packet2.ExchangeId, stillPresent.ExchangeId)
+}

--- a/x/ibc/transwap/keeper/relay_exchange.go
+++ b/x/ibc/transwap/keeper/relay_exchange.go
@@ -264,7 +264,7 @@ func (k Keeper) OnRecvExchangePacket(
 		exchangeID.String(),
 	)
 
-	refundKey := RefundPacketDataKey(types.PortID, swapChannel, sequence)
+	refundKey := GetRefundPacketDataKey(types.PortID, swapChannel, sequence)
 
 	err = k.SetRefundPacketData(ctx, refundKey, &refundMsg)
 	if err != nil {

--- a/x/ibc/transwap/keeper/relay_exchange.go
+++ b/x/ibc/transwap/keeper/relay_exchange.go
@@ -220,16 +220,17 @@ func (k Keeper) OnRecvExchangePacket(
 	// if a channel exists with source channel, then use IBC V1 protocol
 	// otherwise use IBC V2 protocol
 	channel, isIBCV1 := k.channelKeeper.GetChannel(ctx, swapPort, swapChannel)
+	var sequence uint64
 
 	if isIBCV1 {
 		// if a V1 channel exists for the source channel, then use IBC V1 protocol
-		_, err = k.transferV1Packet(ctx, swapChannel, token, uint64(time.Now().Add(10*time.Minute).UnixNano()), packetData) //nolint:gosec // timestamp is always positive
+		sequence, err = k.transferV1Packet(ctx, swapChannel, token, uint64(time.Now().Add(10*time.Minute).UnixNano()), packetData) //nolint:gosec // timestamp is always positive
 		// telemetry for transfer occurs here, in IBC V2 this is done in the onSendPacket callback
 		telemetry.ReportTransfer(swapPort, swapChannel, channel.Counterparty.PortId, channel.Counterparty.ChannelId, token)
 	} else {
 		// otherwise try to send an IBC V2 packet, if the sourceChannel is not a IBC V2 client
 		// then core IBC will return a CounterpartyNotFound error
-		_, err = k.transferV2Packet(ctx, "", swapChannel, uint64(time.Now().Add(10*time.Minute).UnixNano()), packetData) //nolint:gosec // timestamp is always positive
+		sequence, err = k.transferV2Packet(ctx, "", swapChannel, uint64(time.Now().Add(10*time.Minute).UnixNano()), packetData) //nolint:gosec // timestamp is always positive
 	}
 	if err != nil {
 		return errorsmod.Wrapf(err, "unable to send swap tokens: %s", coin.Denom)
@@ -263,9 +264,11 @@ func (k Keeper) OnRecvExchangePacket(
 		exchangeID.String(),
 	)
 
-	err = k.SetRefundPacketData(ctx, destReceiver, &refundMsg)
+	refundKey := RefundPacketDataKey(types.PortID, swapChannel, sequence)
+
+	err = k.SetRefundPacketData(ctx, refundKey, &refundMsg)
 	if err != nil {
-		return errorsmod.Wrapf(err, "unable to set refund packet data: %s", destReceiver)
+		return errorsmod.Wrapf(err, "unable to set refund packet data: %s", refundKey)
 	}
 
 	// The ibc_module.go module will return the proper ack.
@@ -309,9 +312,9 @@ func (k Keeper) OnTimeoutExchangePacket(
 	return k.refundPacketTokens(ctx, sourcePort, sourceChannel, data)
 }
 
-func (k Keeper) performExchangeRefund(ctx sdk.Context, data types.InternalTransferRepresentation) error {
+func (k Keeper) performExchangeRefund(ctx sdk.Context, refundKey string) error {
 	// refund to original source chain
-	refundPacket, err := k.GetRefundPacketData(ctx, data.Receiver)
+	refundPacket, err := k.GetRefundPacketData(ctx, refundKey)
 	if err != nil {
 		return err
 	}
@@ -350,7 +353,7 @@ func (k Keeper) performExchangeRefund(ctx sdk.Context, data types.InternalTransf
 	}
 
 	// delete refund info from store
-	k.DeleteRefundPacketData(ctx, data.Receiver)
+	k.DeleteRefundPacketData(ctx, refundKey)
 
 	return nil
 }

--- a/x/ibc/transwap/keeper/relay_transfer.go
+++ b/x/ibc/transwap/keeper/relay_transfer.go
@@ -109,7 +109,7 @@ func (k Keeper) OnAcknowledgementTransferPacket(
 	data types.InternalTransferRepresentation,
 	ack channeltypes.Acknowledgement,
 ) error {
-	refundKey := RefundPacketDataKey(sourcePort, sourceChannel, sequence)
+	refundKey := GetRefundPacketDataKey(sourcePort, sourceChannel, sequence)
 
 	switch ack.Response.(type) {
 	case *channeltypes.Acknowledgement_Result:
@@ -152,6 +152,6 @@ func (k Keeper) OnTimeoutTransferPacket(
 	}
 
 	// refund to original source chain
-	refundKey := RefundPacketDataKey(sourcePort, sourceChannel, sequence)
+	refundKey := GetRefundPacketDataKey(sourcePort, sourceChannel, sequence)
 	return k.performExchangeRefund(ctx, refundKey)
 }

--- a/x/ibc/transwap/keeper/relay_transfer.go
+++ b/x/ibc/transwap/keeper/relay_transfer.go
@@ -105,13 +105,16 @@ func (k Keeper) OnAcknowledgementTransferPacket(
 	ctx sdk.Context,
 	sourcePort string,
 	sourceChannel string,
+	sequence uint64,
 	data types.InternalTransferRepresentation,
 	ack channeltypes.Acknowledgement,
 ) error {
+	refundKey := RefundPacketDataKey(sourcePort, sourceChannel, sequence)
+
 	switch ack.Response.(type) {
 	case *channeltypes.Acknowledgement_Result:
 		// delete refund info from store
-		k.DeleteRefundPacketData(ctx, data.Receiver)
+		k.DeleteRefundPacketData(ctx, refundKey)
 		// the acknowledgement succeeded on the receiving chain so nothing
 		// needs to be executed and no error needs to be returned
 		return nil
@@ -121,14 +124,14 @@ func (k Keeper) OnAcknowledgementTransferPacket(
 		}
 
 		// refund to original source chain
-		if err := k.performExchangeRefund(ctx, data); err != nil {
+		if err := k.performExchangeRefund(ctx, refundKey); err != nil {
 			return err
 		}
 
 		return nil
 	default:
 		// if the acknowledgement is not a success or error, then return an error
-		if err := k.performExchangeRefund(ctx, data); err != nil {
+		if err := k.performExchangeRefund(ctx, refundKey); err != nil {
 			return err
 		}
 		return errorsmod.Wrapf(ibcerrors.ErrInvalidType, "expected one of [%T, %T], got %T", channeltypes.Acknowledgement_Result{}, channeltypes.Acknowledgement_Error{}, ack.Response)
@@ -140,6 +143,7 @@ func (k Keeper) OnTimeoutTransferPacket(
 	ctx sdk.Context,
 	sourcePort string,
 	sourceChannel string,
+	sequence uint64,
 	data types.InternalTransferRepresentation,
 ) error {
 	// refund the tokens to the sender
@@ -148,5 +152,6 @@ func (k Keeper) OnTimeoutTransferPacket(
 	}
 
 	// refund to original source chain
-	return k.performExchangeRefund(ctx, data)
+	refundKey := RefundPacketDataKey(sourcePort, sourceChannel, sequence)
+	return k.performExchangeRefund(ctx, refundKey)
 }

--- a/x/ibc/transwap/v2/ibc_module.go
+++ b/x/ibc/transwap/v2/ibc_module.go
@@ -169,7 +169,7 @@ func (im *IBCModule) OnTimeoutPacket(ctx sdk.Context, sourceChannel string, dest
 
 	// refund tokens
 	if data.IsTransferPacket() {
-		err = im.keeper.OnTimeoutTransferPacket(ctx, payload.SourcePort, sourceChannel, data)
+		err = im.keeper.OnTimeoutTransferPacket(ctx, payload.SourcePort, sourceChannel, sequence, data)
 	} else {
 		err = im.keeper.OnTimeoutExchangePacket(ctx, payload.SourcePort, sourceChannel, data)
 	}
@@ -203,7 +203,7 @@ func (im *IBCModule) OnAcknowledgementPacket(ctx sdk.Context, sourceChannel stri
 	}
 
 	if data.IsTransferPacket() {
-		err = im.keeper.OnAcknowledgementTransferPacket(ctx, payload.SourcePort, sourceChannel, data, ack)
+		err = im.keeper.OnAcknowledgementTransferPacket(ctx, payload.SourcePort, sourceChannel, sequence, data, ack)
 	} else {
 		err = im.keeper.OnAcknowledgementExchangePacket(ctx, payload.SourcePort, sourceChannel, data, ack)
 	}


### PR DESCRIPTION
# Description

This PR fixes a critical data integrity bug in the `x/ibc/transwap` module where refund packet data was being overwritten.

Previously, the module used the **Receiver address** as the primary key for tracking pending refunds. This caused data collisions and overwrites when multiple IBC packets were processed for the same receiver. This PR refactors the state management to use a unique combination of **Port, Channel, and Sequence** as the storage key, ensuring that each packet's refund data is uniquely identified and preserved.

Additionally, this PR includes a security update for the core consensus engine to address a high-severity vulnerability.

### Key Changes:

**Refactor Refund Storage Key**:
 * Changed the lookup and storage logic in `x/ibc/transwap/keeper/relay.go` from using `Receiver` as a key to using the unique IBC packet identifier: `(PortID, ChannelID, Sequence)`.
 * This ensures that concurrent or sequential packets for the same user do not overwrite each other's refund state.


**Security Update (CometBFT)**:
 * Updated `github.com/cometbft/cometbft` from `v0.38.19` to `v0.38.21`.
 * This addresses **GHSA-c32p-wcqj-j677**, fixing inconsistencies between commit signature verification and block time derivation.


**Regression Testing**:
 * Added `x/ibc/transwap/keeper/refund_packet_data_test.go` to verify that distinct packets for the same receiver are now tracked separately without data loss or collisions.



### Critical Files to Review:

* `x/ibc/transwap/keeper/relay.go`: Modification of the storage key logic.
* `x/ibc/transwap/keeper/refund_packet_data_test.go`: Tests for unique packet tracking.
* `go.mod` & `go.sum`: Dependency security bump.

# How to review

* **Verify Key Logic**: Ensure the `SetRefundPacketData` and `GetRefundPacketData` calls correctly utilize the packet-specific identifiers (port, channel, sequence) instead of the receiver address.
* **Dependency Check**: Confirm that `CometBFT` is correctly updated to `v0.38.21` in `go.mod`.
* **Race Condition Analysis**: Verify that the new key structure effectively prevents state overwrites during high-concurrency IBC transfers.

# Testing

* **Unit Tests**: Executed `go test ./x/ibc/transwap/...` and confirmed that multi-packet scenarios for a single receiver now pass correctly.
* **Security Verification**: Confirmed the build is successful with CometBFT v0.38.21 and passes dependency review checks.
* **Manual Verification**: Verified version info outputs `0.38.21` after rebuilding the binary.

# Changelog Entry

### Fixed

* [x/ibc/transwap] Prevented refund data overwrite by changing storage keys from Receiver address to unique packet identifiers (Port, Channel, Sequence).
* [security] Updated CometBFT to v0.38.21 to fix a high-severity vulnerability (GHSA-c32p-wcqj-j677).

Closes: #XXXX

---

## Author Checklist

I have...

* [x] tackled an existing issue or discussed with a team member
* [x] left instructions on how to review the changes
* [x] targeted the `main` branch

## Reviewers Checklist

I have...

* [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
* [ ] confirmed all author checklist items have been addressed
* [ ] confirmed that this PR does not change production code
* [ ] reviewed content
* [ ] tested instructions (if applicable)
* [ ] confirmed all CI checks have passed