### PR TITLE
feat(feepolicy): global message fee policy and single-msg tx discounts

### DIFF
--- a/gurud/ante/cosmos_fees.go
+++ b/gurud/ante/cosmos_fees.go
@@ -82,33 +82,11 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 		}
 	}
 
-	discount := dfd.feepolicyKeeper.GetDiscount(ctx, feeGranter, tx.GetMsgs())
+	discount := dfd.feepolicyKeeper.ResolveDiscount(ctx, feeGranter, tx.GetMsgs())
 
 	// apply discounts
-	var deductedFee sdk.Coins
 	baseFee := fee.Sub(tips...)
-
-	switch discount.DiscountType {
-	case feepolicytypes.FeeDiscountTypePercent:
-		for _, f := range baseFee {
-			// Calculate percentage multiplier as (100 - discountAmount) / 100
-			// Example: if discount = 25.5%, multiplier = 0.745
-			discountMultiplier := math.LegacyNewDec(100).Sub(discount.Amount).Quo(math.LegacyNewDec(100))
-
-			// Apply multiplier to base fee amount
-			finalAmt := math.LegacyNewDecFromInt(f.Amount).Mul(discountMultiplier).TruncateInt()
-
-			deductedFee = deductedFee.Add(sdk.NewCoin(f.Denom, finalAmt))
-		}
-	case feepolicytypes.FeeDiscountTypeFixed:
-		for _, f := range baseFee {
-			// type: "fixed"
-			deductedFee = deductedFee.Add(sdk.NewCoin(f.Denom, discount.Amount.TruncateInt()))
-		}
-	default:
-		// if no discount, deduct full fee
-		deductedFee = baseFee
-	}
+	deductedFee := applyDiscountToBaseFee(baseFee, discount)
 	deductedFee = deductedFee.Add(tips...)
 
 	if err = dfd.checkDeductFee(ctx, tx, deductedFee); err != nil {
@@ -118,6 +96,48 @@ func (dfd DeductFeeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulate bo
 	newCtx := ctx.WithPriority(priority)
 
 	return next(newCtx, tx, simulate)
+}
+
+func applyDiscountToBaseFee(baseFee sdk.Coins, discount feepolicytypes.Discount) sdk.Coins {
+	var deductedFee sdk.Coins
+	switch discount.DiscountType {
+	case feepolicytypes.FeeDiscountTypePercent:
+		discountMultiplier := math.LegacyNewDec(100).Sub(discount.Amount).Quo(math.LegacyNewDec(100))
+		if discountMultiplier.IsNegative() {
+			discountMultiplier = math.LegacyZeroDec()
+		}
+
+		for _, f := range baseFee {
+			finalAmt := math.LegacyNewDecFromInt(f.Amount).Mul(discountMultiplier).TruncateInt()
+			if finalAmt.IsNegative() {
+				finalAmt = math.ZeroInt()
+			}
+			// Never charge more than the original base fee amount.
+			if finalAmt.GT(f.Amount) {
+				finalAmt = f.Amount
+			}
+
+			deductedFee = deductedFee.Add(sdk.NewCoin(f.Denom, finalAmt))
+		}
+	case feepolicytypes.FeeDiscountTypeFixed:
+		fixedAmt := discount.Amount.TruncateInt()
+		if fixedAmt.IsNegative() {
+			fixedAmt = math.ZeroInt()
+		}
+
+		for _, f := range baseFee {
+			finalAmt := fixedAmt
+			// Never charge more than the original base fee amount.
+			if finalAmt.GT(f.Amount) {
+				finalAmt = f.Amount
+			}
+			deductedFee = deductedFee.Add(sdk.NewCoin(f.Denom, finalAmt))
+		}
+	default:
+		deductedFee = baseFee
+	}
+
+	return deductedFee
 }
 
 func (dfd DeductFeeDecorator) checkDeductFee(ctx sdk.Context, sdkTx sdk.Tx, fee sdk.Coins) error {

--- a/gurud/ante/cosmos_fees_test.go
+++ b/gurud/ante/cosmos_fees_test.go
@@ -1,0 +1,48 @@
+package ante
+
+import (
+	"testing"
+
+	"cosmossdk.io/math"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
+
+	feepolicytypes "github.com/gurufinglobal/guru/v2/x/feepolicy/types"
+)
+
+func TestApplyDiscountToBaseFee(t *testing.T) {
+	baseFee := sdk.NewCoins(
+		sdk.NewCoin("aguru", math.NewInt(100)),
+		sdk.NewCoin("aguru2", math.NewInt(80)),
+	)
+
+	t.Run("percent discount", func(t *testing.T) {
+		discounted := applyDiscountToBaseFee(baseFee, feepolicytypes.Discount{
+			DiscountType: feepolicytypes.FeeDiscountTypePercent,
+			Amount:       math.LegacyNewDec(25),
+		})
+
+		require.Equal(t, math.NewInt(75), discounted.AmountOf("aguru"))
+		require.Equal(t, math.NewInt(60), discounted.AmountOf("aguru2"))
+	})
+
+	t.Run("percent over 100 is clamped", func(t *testing.T) {
+		discounted := applyDiscountToBaseFee(baseFee, feepolicytypes.Discount{
+			DiscountType: feepolicytypes.FeeDiscountTypePercent,
+			Amount:       math.LegacyNewDec(150),
+		})
+
+		require.True(t, discounted.IsZero())
+	})
+
+	t.Run("fixed discount is capped by original fee", func(t *testing.T) {
+		discounted := applyDiscountToBaseFee(baseFee, feepolicytypes.Discount{
+			DiscountType: feepolicytypes.FeeDiscountTypeFixed,
+			Amount:       math.LegacyNewDec(90),
+		})
+
+		require.Equal(t, math.NewInt(90), discounted.AmountOf("aguru"))
+		require.Equal(t, math.NewInt(80), discounted.AmountOf("aguru2"))
+	})
+}

--- a/gurud/ante/interfaces.go
+++ b/gurud/ante/interfaces.go
@@ -7,5 +7,5 @@ import (
 )
 
 type FeePolicyKeeper interface {
-	GetDiscount(ctx sdk.Context, feePayerAddr string, msgs []sdk.Msg) feepolicytypes.Discount
+	ResolveDiscount(ctx sdk.Context, feePayerAddr string, msgs []sdk.Msg) feepolicytypes.Discount
 }

--- a/x/feepolicy/keeper/keeper.go
+++ b/x/feepolicy/keeper/keeper.go
@@ -14,6 +14,8 @@ import (
 	"github.com/gurufinglobal/guru/v2/x/feepolicy/types"
 )
 
+const globalDiscountStoreKey = "__global__"
+
 // Keeper of the xmsquare store
 type Keeper struct {
 	// Protobuf codec
@@ -97,7 +99,7 @@ func (k Keeper) GetAccountDiscounts(ctx sdk.Context, accStr string) (types.Accou
 	store := ctx.KVStore(k.storeKey)
 	discountStore := prefix.NewStore(store, types.KeyDiscounts)
 
-	bz := discountStore.Get([]byte(accStr))
+	bz := discountStore.Get(discountStoreKey(accStr))
 	if bz == nil {
 		return types.AccountDiscount{}, false
 	}
@@ -109,16 +111,10 @@ func (k Keeper) GetAccountDiscounts(ctx sdk.Context, accStr string) (types.Accou
 }
 
 func (k Keeper) GetModuleDiscounts(ctx sdk.Context, accStr, module string) ([]types.Discount, bool) {
-	store := ctx.KVStore(k.storeKey)
-	discountStore := prefix.NewStore(store, types.KeyDiscounts)
-
-	bz := discountStore.Get([]byte(accStr))
-	if bz == nil {
+	accDiscount, ok := k.GetAccountDiscounts(ctx, accStr)
+	if !ok {
 		return nil, false
 	}
-
-	accDiscount := types.AccountDiscount{}
-	k.cdc.MustUnmarshal(bz, &accDiscount)
 
 	for _, discount := range accDiscount.Modules {
 		if discount.Module == module {
@@ -132,13 +128,13 @@ func (k Keeper) GetModuleDiscounts(ctx sdk.Context, accStr, module string) ([]ty
 func (k Keeper) SetAccountDiscounts(ctx sdk.Context, discount types.AccountDiscount) {
 	store := ctx.KVStore(k.storeKey)
 	discountStore := prefix.NewStore(store, types.KeyDiscounts)
-	discountStore.Set([]byte(discount.Address), k.cdc.MustMarshal(&discount))
+	discountStore.Set(discountStoreKey(discount.Address), k.cdc.MustMarshal(&discount))
 }
 
 func (k Keeper) DeleteAccountDiscounts(ctx sdk.Context, accStr string) {
 	store := ctx.KVStore(k.storeKey)
 	discountStore := prefix.NewStore(store, types.KeyDiscounts)
-	discountStore.Delete([]byte(accStr))
+	discountStore.Delete(discountStoreKey(accStr))
 }
 
 func (k Keeper) DeleteModuleDiscounts(ctx sdk.Context, accStr, module string) {
@@ -175,28 +171,31 @@ func (k Keeper) DeleteMsgTypeDiscounts(ctx sdk.Context, accStr, msgType string) 
 	k.SetAccountDiscounts(ctx, discounts)
 }
 
-func (k Keeper) GetDiscount(ctx sdk.Context, feePayerAddr string, msgs []sdk.Msg) types.Discount {
-	accDiscount, ok := k.GetAccountDiscounts(ctx, feePayerAddr)
-	if !ok {
+func (k Keeper) ResolveDiscount(ctx sdk.Context, feePayerAddr string, msgs []sdk.Msg) types.Discount {
+	// Never apply discounts to multi-message txs.
+	if len(msgs) != 1 {
 		return types.Discount{}
 	}
 
-	discount := types.Discount{}
-	module := ""
-	for _, m := range msgs {
-		t := sdk.MsgTypeURL(m) // converts from (ex.) *types.MsgRecvPacket to "/ibc.core.channel.v1.MsgRecvPacket"
-		for _, moduleDiscount := range accDiscount.Modules {
-			for _, d := range moduleDiscount.Discounts {
-				if d.MsgType == t {
-					discount = d
-					module = moduleDiscount.Module
-					break
-				}
-			}
-		}
+	discount, module, ok := k.getMatchedDiscount(ctx, feePayerAddr, msgs)
+	if ok {
+		return k.getDiscountWithModuleCheck(ctx, discount, module, msgs)
 	}
 
-	// check if the module has additional checker layers
+	discount, module, ok = k.getMatchedDiscount(ctx, "", msgs)
+	if ok {
+		return k.getDiscountWithModuleCheck(ctx, discount, module, msgs)
+	}
+
+	return types.Discount{}
+}
+
+// GetDiscount keeps backward compatibility and proxies to ResolveDiscount.
+func (k Keeper) GetDiscount(ctx sdk.Context, feePayerAddr string, msgs []sdk.Msg) types.Discount {
+	return k.ResolveDiscount(ctx, feePayerAddr, msgs)
+}
+
+func (k Keeper) getDiscountWithModuleCheck(ctx sdk.Context, discount types.Discount, module string, msgs []sdk.Msg) types.Discount {
 	if k.moduleKeepers[module] == nil {
 		return discount
 	}
@@ -205,4 +204,29 @@ func (k Keeper) GetDiscount(ctx sdk.Context, feePayerAddr string, msgs []sdk.Msg
 	}
 
 	return types.Discount{}
+}
+
+func (k Keeper) getMatchedDiscount(ctx sdk.Context, accStr string, msgs []sdk.Msg) (types.Discount, string, bool) {
+	accDiscount, ok := k.GetAccountDiscounts(ctx, accStr)
+	if !ok || len(msgs) == 0 {
+		return types.Discount{}, "", false
+	}
+
+	msgTypeURL := sdk.MsgTypeURL(msgs[0])
+	for _, moduleDiscount := range accDiscount.Modules {
+		for _, d := range moduleDiscount.Discounts {
+			if d.MsgType == msgTypeURL {
+				return d, moduleDiscount.Module, true
+			}
+		}
+	}
+
+	return types.Discount{}, "", false
+}
+
+func discountStoreKey(address string) []byte {
+	if address == "" {
+		return []byte(globalDiscountStoreKey)
+	}
+	return []byte(address)
 }

--- a/x/feepolicy/keeper/keeper_test.go
+++ b/x/feepolicy/keeper/keeper_test.go
@@ -130,3 +130,68 @@ func TestKeeperGetDiscountAndLogger(t *testing.T) {
 	discount = nw.App.FeePolicyKeeper.GetDiscount(ctx, addr2, []sdk.Msg{msg})
 	require.Equal(t, types.Discount{}, discount)
 }
+
+func TestKeeperResolveDiscount_GlobalFallbackAndMultiMsg(t *testing.T) {
+	nw := network.NewUnitTestNetwork()
+	ctx := nw.GetContext()
+
+	const (
+		addr1 = "guru1gzsvk8rruqn2sx64acfsskrwy8hvrmaf6dvhj3"
+		addr2 = "guru1qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqg3d5d2"
+		addr3 = "guru1qypqxpq9qcrsszg2pvxq6rs0zqg3yyc5f2m6u8"
+	)
+
+	globalDiscount := types.AccountDiscount{
+		Address: "",
+		Modules: []types.ModuleDiscount{
+			{
+				Module: "bank",
+				Discounts: []types.Discount{
+					{
+						DiscountType: "percent",
+						MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+						Amount:       sdkmath.LegacyNewDec(25),
+					},
+				},
+			},
+		},
+	}
+	nw.App.FeePolicyKeeper.SetAccountDiscounts(ctx, globalDiscount)
+
+	accountDiscount := types.AccountDiscount{
+		Address: addr1,
+		Modules: []types.ModuleDiscount{
+			{
+				Module: "bank",
+				Discounts: []types.Discount{
+					{
+						DiscountType: "percent",
+						MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+						Amount:       sdkmath.LegacyNewDec(10),
+					},
+				},
+			},
+		},
+	}
+	nw.App.FeePolicyKeeper.SetAccountDiscounts(ctx, accountDiscount)
+
+	msgSend := &banktypes.MsgSend{
+		FromAddress: addr1,
+		ToAddress:   addr2,
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin("agxn", 1)),
+	}
+	msgSend2 := &banktypes.MsgSend{
+		FromAddress: addr1,
+		ToAddress:   addr3,
+		Amount:      sdk.NewCoins(sdk.NewInt64Coin("agxn", 1)),
+	}
+
+	discount := nw.App.FeePolicyKeeper.ResolveDiscount(ctx, addr1, []sdk.Msg{msgSend})
+	require.Equal(t, accountDiscount.Modules[0].Discounts[0], discount)
+
+	discount = nw.App.FeePolicyKeeper.ResolveDiscount(ctx, addr2, []sdk.Msg{msgSend})
+	require.Equal(t, globalDiscount.Modules[0].Discounts[0], discount)
+
+	discount = nw.App.FeePolicyKeeper.ResolveDiscount(ctx, addr2, []sdk.Msg{msgSend, msgSend2})
+	require.Equal(t, types.Discount{}, discount)
+}

--- a/x/feepolicy/types/discount.go
+++ b/x/feepolicy/types/discount.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	errorsmod "cosmossdk.io/errors"
+	"cosmossdk.io/math"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
@@ -26,6 +27,9 @@ func ValidateFeeDiscount(discount Discount) error {
 	if discount.Amount.IsNegative() || discount.Amount.IsZero() {
 		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "discount value must be greater than 0")
 	}
+	if discount.DiscountType == FeeDiscountTypePercent && discount.Amount.GT(math.LegacyNewDec(100)) {
+		return errorsmod.Wrap(sdkerrors.ErrInvalidRequest, "percent discount must be less than or equal to 100")
+	}
 
 	return nil
 }
@@ -33,9 +37,12 @@ func ValidateFeeDiscount(discount Discount) error {
 // ValidateAccountDiscount validates an account discount
 // AccountDiscount contains all discounts for a single account
 func ValidateAccountDiscount(discount AccountDiscount) error {
-	_, err := sdk.AccAddressFromBech32(discount.Address)
-	if err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
+	// Empty address is reserved for global discount policy.
+	if discount.Address != "" {
+		_, err := sdk.AccAddressFromBech32(discount.Address)
+		if err != nil {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, "string could not be parsed as address: %v", err)
+		}
 	}
 
 	for _, moduleDiscount := range discount.Modules {

--- a/x/feepolicy/types/discount_test.go
+++ b/x/feepolicy/types/discount_test.go
@@ -68,11 +68,76 @@ func (suite *DiscountTestSuite) TestDiscountValidate() {
 			},
 			true,
 		},
+		{
+			"invalid: percent discount is greater than 100",
+			Discount{
+				DiscountType: "percent",
+				MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+				Amount:       math.LegacyNewDec(101),
+			},
+			true,
+		},
 	}
 
 	for _, tc := range testCases {
 		err := ValidateFeeDiscount(tc.discount)
 
+		if tc.expError {
+			suite.Require().Error(err, tc.name)
+		} else {
+			suite.Require().NoError(err, tc.name)
+		}
+	}
+}
+
+func (suite *DiscountTestSuite) TestAccountDiscountValidate() {
+	testCases := []struct {
+		name     string
+		discount AccountDiscount
+		expError bool
+	}{
+		{
+			name: "valid global discount with empty address",
+			discount: AccountDiscount{
+				Address: "",
+				Modules: []ModuleDiscount{
+					{
+						Module: "bank",
+						Discounts: []Discount{
+							{
+								DiscountType: "percent",
+								MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+								Amount:       math.LegacyNewDec(10),
+							},
+						},
+					},
+				},
+			},
+			expError: false,
+		},
+		{
+			name: "invalid account address",
+			discount: AccountDiscount{
+				Address: "invalid",
+				Modules: []ModuleDiscount{
+					{
+						Module: "bank",
+						Discounts: []Discount{
+							{
+								DiscountType: "percent",
+								MsgType:      "/cosmos.bank.v1beta1.MsgSend",
+								Amount:       math.LegacyNewDec(10),
+							},
+						},
+					},
+				},
+			},
+			expError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		err := ValidateAccountDiscount(tc.discount)
 		if tc.expError {
 			suite.Require().Error(err, tc.name)
 		} else {

--- a/x/feepolicy/types/msg_test.go
+++ b/x/feepolicy/types/msg_test.go
@@ -197,6 +197,16 @@ func (suite *MsgsTestSuite) TestMsgRemoveDiscounts() {
 			},
 			true,
 		},
+		{
+			"pass - valid global remove msg",
+			&MsgRemoveDiscounts{
+				ModeratorAddress: authtypes.NewModuleAddress(govtypes.ModuleName).String(),
+				Address:          "",
+				Module:           "bank",
+				MsgType:          "/cosmos.bank.v1beta1.MsgSend",
+			},
+			true,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/x/feepolicy/types/msgs.go
+++ b/x/feepolicy/types/msgs.go
@@ -119,8 +119,10 @@ func (msg MsgRemoveDiscounts) ValidateBasic() error {
 	if _, err := sdk.AccAddressFromBech32(msg.ModeratorAddress); err != nil {
 		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, " moderator address, %s", err)
 	}
-	if _, err := sdk.AccAddressFromBech32(msg.Address); err != nil {
-		return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, " discount address, %s", err)
+	if msg.Address != "" {
+		if _, err := sdk.AccAddressFromBech32(msg.Address); err != nil {
+			return errorsmod.Wrapf(sdkerrors.ErrInvalidAddress, " discount address, %s", err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- **Chain-wide policy**: When `AccountDiscount` has an empty address, treat it as a chain-wide message fee policy. Persist it under an internal KV sentinel key while keeping `Address` as `""` in stored protobuf.
- **Discount resolution**: Add `ResolveDiscount` — prefer per-account match, then fall back to global policy. **No discounts** when `len(msgs) != 1`. Keep `GetDiscount` as a compatibility alias.
- **Ante**: Wire `DeductFeeDecorator` to `ResolveDiscount`; centralize base fee adjustment with caps so deducted fees never exceed pre-tip base or go negative.
- **Validation**: Allow empty address in `ValidateAccountDiscount` and `MsgRemoveDiscounts`; reject percent discount amounts greater than 100.
- **Tests**: Keeper and ante unit tests for global fallback, multi-msg exclusion, and fee math edge cases.

## Scope

- `x/feepolicy` (keeper, types, validation)
- `gurud/ante` (fee deduction decorator)

## Notes

- Multi-message transactions no longer receive discounts; communicate this if users batch multiple messages in one transaction.